### PR TITLE
Scripting enhancements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
     id("dev.yumi.gradle.licenser") version("+")
     id("org.ajoberstar.grgit") version("+")
     id("com.modrinth.minotaur") version("+")
+    id("com.github.johnrengelman.shadow") version("+")
     eclipse
     idea
     `java-library`
@@ -108,6 +109,7 @@ loom {
 
 val includeModApi: Configuration by configurations.creating
 val includeImplementation: Configuration by configurations.creating
+val shadowInclude: Configuration by configurations.creating
 
 configurations {
     include {
@@ -205,7 +207,7 @@ dependencies {
     modImplementation("net.fabricmc:fabric-language-kotlin:${fabric_kotlin_version}")
 
     // Kotlin Metadata Remapping
-    api(files("libs/fabric-loom-1.6.local-kotlin-remapper.jar"))?.let { include(it) }
+    api(files("libs/fabric-loom-1.6.local-kotlin-remapper.jar"))?.let { shadowInclude(it) }
 
     // get deps manually because FKE cant give them to compile classpath without an error
     api("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.9.0")
@@ -273,6 +275,16 @@ tasks {
     //    include("**/*.java")
     //}
 
+    test {
+        useJUnitPlatform()
+    }
+
+    shadowJar {
+        configurations = listOf(shadowInclude)
+        isEnableRelocation = true
+        relocationPrefix = "net.frozenblock.configurableeverything.shadow"
+    }
+
     register("javadocJar", Jar::class) {
         dependsOn(javadoc)
         archiveClassifier.set("javadoc")
@@ -283,6 +295,11 @@ tasks {
         dependsOn(classes)
         archiveClassifier.set("sources")
         from(sourceSets.main.get().allSource)
+    }
+
+    remapJar {
+        dependsOn(shadowJar)
+        input = shadowJar.get().archiveFile
     }
 
     withType(JavaCompile::class) {

--- a/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomeChange.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomeChange.kt
@@ -4,19 +4,19 @@ import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 
 data class BiomeChange(
-	@JvmField var addedFeatures: List<BiomePlacedFeatureList>,
-	@JvmField var removedFeatures: List<BiomePlacedFeatureList>,
-	@JvmField var replacedFeatures: List<BiomePlacedFeatureReplacementList>,
-	@JvmField var musicReplacements: List<BiomeMusic>
+	@JvmField var addedFeatures: MutableList<BiomePlacedFeatureList>,
+	@JvmField var removedFeatures: MutableList<BiomePlacedFeatureList>,
+	@JvmField var replacedFeatures: MutableList<BiomePlacedFeatureReplacementList>,
+	@JvmField var musicReplacements: MutableList<BiomeMusic>
 ) {
 	companion object {
 		@JvmField
 		val CODEC: Codec<BiomeChange> = RecordCodecBuilder.create { instance ->
 			instance.group(
-				BiomePlacedFeatureList.CODEC.listOf().fieldOf("addedFeatures").forGetter(BiomeChange::addedFeatures),
-				BiomePlacedFeatureList.CODEC.listOf().fieldOf("removedFeatures").forGetter(BiomeChange::removedFeatures),
-				BiomePlacedFeatureReplacementList.CODEC.listOf().fieldOf("replacedFeatures").forGetter(BiomeChange::replacedFeatures),
-				BiomeMusic.CODEC.listOf().fieldOf("musicReplacements").forGetter(BiomeChange::musicReplacements)
+				BiomePlacedFeatureList.CODEC.mutListOf().fieldOf("addedFeatures").forGetter(BiomeChange::addedFeatures),
+				BiomePlacedFeatureList.CODEC.mutListOf().fieldOf("removedFeatures").forGetter(BiomeChange::removedFeatures),
+				BiomePlacedFeatureReplacementList.CODEC.mutListOf().fieldOf("replacedFeatures").forGetter(BiomeChange::replacedFeatures),
+				BiomeMusic.CODEC.mutListOf().fieldOf("musicReplacements").forGetter(BiomeChange::musicReplacements)
 			).apply(instance, ::BiomeChange)
 		}
 	}

--- a/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomeChange.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomeChange.kt
@@ -2,6 +2,7 @@ package net.frozenblock.configurableeverything.biome.util
 
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 
 data class BiomeChange(
 	@JvmField var addedFeatures: MutableList<BiomePlacedFeatureList>,

--- a/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomeChanges.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomeChanges.kt
@@ -25,9 +25,9 @@ object BiomeChanges : DataReloadManager<BiomeChange>(
      */
     internal inline fun add(
         key: ResourceLocation,
-        addedFeatures: List<BiomePlacedFeatureList>,
-        removedFeatures: List<BiomePlacedFeatureList>,
-        replacedFeatures: List<BiomePlacedFeatureReplacementList>,
-        musicReplacements: List<BiomeMusic>
+        addedFeatures: MutableList<BiomePlacedFeatureList>,
+        removedFeatures: MutableList<BiomePlacedFeatureList>,
+        replacedFeatures: MutableList<BiomePlacedFeatureReplacementList>,
+        musicReplacements: MutableList<BiomeMusic>
     ) = add(key, BiomeChange(addedFeatures, removedFeatures, replacedFeatures, musicReplacements))
 }

--- a/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomeConfigUtil.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomeConfigUtil.kt
@@ -7,6 +7,7 @@ import net.fabricmc.fabric.api.biome.v1.*
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper
 import net.frozenblock.configurableeverything.config.BiomeConfig
 import net.frozenblock.configurableeverything.config.MainConfig
+import net.frozenblock.configurableeverything.scripting.util.ConfigData
 import net.frozenblock.configurableeverything.util.id
 import net.frozenblock.configurableeverything.util.value
 import net.frozenblock.lib.sound.api.asImmutable

--- a/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomeMusic.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomeMusic.kt
@@ -3,6 +3,7 @@ package net.frozenblock.configurableeverything.biome.util
 import com.mojang.datafixers.util.Either
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 import net.frozenblock.lib.sound.api.MutableMusic
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceKey

--- a/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomePlacedFeatureList.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomePlacedFeatureList.kt
@@ -3,6 +3,7 @@ package net.frozenblock.configurableeverything.biome.util
 import com.mojang.datafixers.util.Either
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceKey
 import net.minecraft.tags.TagKey

--- a/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomePlacedFeatureList.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomePlacedFeatureList.kt
@@ -10,7 +10,7 @@ import net.minecraft.world.level.biome.Biome
 
 data class BiomePlacedFeatureList(
     @JvmField var biome: Either<ResourceKey<Biome>, TagKey<Biome>>,
-    @JvmField var features: List<DecorationStepPlacedFeature>
+    @JvmField var features: MutableList<DecorationStepPlacedFeature>
 ) {
     companion object {
         @JvmField
@@ -19,7 +19,7 @@ data class BiomePlacedFeatureList(
                 Codec.either(
                     ResourceKey.codec(Registries.BIOME), TagKey.hashedCodec(Registries.BIOME)
                 ).fieldOf("biome").forGetter(BiomePlacedFeatureList::biome),
-                DecorationStepPlacedFeature.CODEC.listOf().fieldOf("placed_features").forGetter(BiomePlacedFeatureList::features)
+                DecorationStepPlacedFeature.CODEC.mutListOf().fieldOf("placed_features").forGetter(BiomePlacedFeatureList::features)
             ).apply(instance, ::BiomePlacedFeatureList)
         }
     }

--- a/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomePlacedFeatureReplacementList.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomePlacedFeatureReplacementList.kt
@@ -3,6 +3,7 @@ package net.frozenblock.configurableeverything.biome.util
 import com.mojang.datafixers.util.Either
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceKey
 import net.minecraft.tags.TagKey

--- a/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomePlacedFeatureReplacementList.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome/util/BiomePlacedFeatureReplacementList.kt
@@ -10,14 +10,14 @@ import net.minecraft.world.level.biome.Biome
 
 data class BiomePlacedFeatureReplacementList(
     @JvmField var biome: Either<ResourceKey<Biome>, TagKey<Biome>>,
-    @JvmField var replacements: List<PlacedFeatureReplacement>
+    @JvmField var replacements: MutableList<PlacedFeatureReplacement>
 ) {
 	companion object {
 		@JvmField
 		val CODEC: Codec<BiomePlacedFeatureReplacementList> = RecordCodecBuilder.create { instance ->
 			instance.group(
 				Codec.either(ResourceKey.codec(Registries.BIOME), TagKey.hashedCodec(Registries.BIOME)).fieldOf("biome").forGetter(BiomePlacedFeatureReplacementList::biome),
-				PlacedFeatureReplacement.CODEC.listOf().fieldOf("replacements").forGetter(BiomePlacedFeatureReplacementList::replacements)
+				PlacedFeatureReplacement.CODEC.mutListOf().fieldOf("replacements").forGetter(BiomePlacedFeatureReplacementList::replacements)
 			).apply(instance, ::BiomePlacedFeatureReplacementList)
 		}
 	}

--- a/src/main/java/net/frozenblock/configurableeverything/biome/util/DecorationStepPlacedFeature.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome/util/DecorationStepPlacedFeature.kt
@@ -9,14 +9,14 @@ import net.minecraft.world.level.levelgen.placement.PlacedFeature
 
 data class DecorationStepPlacedFeature(
 	@JvmField var decoration: GenerationStep.Decoration,
-	@JvmField var placedFeatures: List<ResourceKey<PlacedFeature>>
+	@JvmField var placedFeatures: MutableList<ResourceKey<PlacedFeature>>
 ) {
 	companion object {
 		@JvmField
 		val CODEC: Codec<DecorationStepPlacedFeature> = RecordCodecBuilder.create { instance ->
 			instance.group(
 				GenerationStep.Decoration.CODEC.fieldOf("decoration").forGetter(DecorationStepPlacedFeature::decoration),
-				ResourceKey.codec(Registries.PLACED_FEATURE).listOf().fieldOf("placed_features").forGetter(DecorationStepPlacedFeature::placedFeatures)
+				ResourceKey.codec(Registries.PLACED_FEATURE).mutListOf().fieldOf("placed_features").forGetter(DecorationStepPlacedFeature::placedFeatures)
 			).apply(instance, ::DecorationStepPlacedFeature)
 		}
 	}

--- a/src/main/java/net/frozenblock/configurableeverything/biome/util/DecorationStepPlacedFeature.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome/util/DecorationStepPlacedFeature.kt
@@ -2,6 +2,7 @@ package net.frozenblock.configurableeverything.biome.util
 
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceKey
 import net.minecraft.world.level.levelgen.GenerationStep

--- a/src/main/java/net/frozenblock/configurableeverything/biome/util/PlacedFeatureReplacement.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome/util/PlacedFeatureReplacement.kt
@@ -2,6 +2,7 @@ package net.frozenblock.configurableeverything.biome.util
 
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceKey
 import net.minecraft.world.level.levelgen.placement.PlacedFeature

--- a/src/main/java/net/frozenblock/configurableeverything/biome_placement/util/BiomePlacementChange.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome_placement/util/BiomePlacementChange.kt
@@ -2,10 +2,11 @@ package net.frozenblock.configurableeverything.biome_placement.util
 
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 
 data class BiomePlacementChange(
-	@JvmField var addedBiomes: MutableList<DimensionBiomeList?>?,
-	@JvmField var removedBiomes: MutableList<DimensionBiomeKeyList?>?
+	@JvmField var addedBiomes: MutableList<DimensionBiomeList>,
+	@JvmField var removedBiomes: MutableList<DimensionBiomeKeyList>
 ) {
 	companion object {
         @JvmField

--- a/src/main/java/net/frozenblock/configurableeverything/biome_placement/util/BiomePlacementChange.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome_placement/util/BiomePlacementChange.kt
@@ -4,15 +4,15 @@ import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
 
 data class BiomePlacementChange(
-	@JvmField var addedBiomes: List<DimensionBiomeList?>?,
-	@JvmField var removedBiomes: List<DimensionBiomeKeyList?>?
+	@JvmField var addedBiomes: MutableList<DimensionBiomeList?>?,
+	@JvmField var removedBiomes: MutableList<DimensionBiomeKeyList?>?
 ) {
 	companion object {
         @JvmField
 		val CODEC: Codec<BiomePlacementChange> = RecordCodecBuilder.create { instance ->
 			instance.group(
-				DimensionBiomeList.CODEC.listOf().fieldOf("addedBiomes").forGetter(BiomePlacementChange::addedBiomes),
-				DimensionBiomeKeyList.CODEC.listOf().fieldOf("removedBiomes").forGetter(BiomePlacementChange::removedBiomes)
+				DimensionBiomeList.CODEC.mutListOf().fieldOf("addedBiomes").forGetter(BiomePlacementChange::addedBiomes),
+				DimensionBiomeKeyList.CODEC.mutListOf().fieldOf("removedBiomes").forGetter(BiomePlacementChange::removedBiomes)
 			).apply(instance, ::BiomePlacementChange)
 		}
 	}

--- a/src/main/java/net/frozenblock/configurableeverything/biome_placement/util/DimensionBiomeKeyList.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome_placement/util/DimensionBiomeKeyList.kt
@@ -3,6 +3,7 @@ package net.frozenblock.configurableeverything.biome_placement.util
 import com.mojang.datafixers.util.Either
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceKey
 import net.minecraft.tags.TagKey

--- a/src/main/java/net/frozenblock/configurableeverything/biome_placement/util/DimensionBiomeKeyList.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome_placement/util/DimensionBiomeKeyList.kt
@@ -11,14 +11,14 @@ import net.minecraft.world.level.dimension.DimensionType
 
 data class DimensionBiomeKeyList(
 	@JvmField var dimension: ResourceKey<DimensionType>,
-	@JvmField var biomes: List<Either<ResourceKey<Biome> , TagKey<Biome>>>
+	@JvmField var biomes: MutableList<Either<ResourceKey<Biome> , TagKey<Biome>>>
 ) {
 	companion object {
         @JvmField
 		val CODEC: Codec<DimensionBiomeKeyList> = RecordCodecBuilder.create { instance ->
 			instance.group(
 				ResourceKey.codec(Registries.DIMENSION_TYPE).fieldOf("dimension").forGetter(DimensionBiomeKeyList::dimension),
-				Codec.either(ResourceKey.codec(Registries.BIOME), TagKey.hashedCodec(Registries.BIOME)).listOf().fieldOf("biomes").forGetter(DimensionBiomeKeyList::biomes)
+				Codec.either(ResourceKey.codec(Registries.BIOME), TagKey.hashedCodec(Registries.BIOME)).mutListOf().fieldOf("biomes").forGetter(DimensionBiomeKeyList::biomes)
 			).apply(instance, ::DimensionBiomeKeyList)
 		}
 	}

--- a/src/main/java/net/frozenblock/configurableeverything/biome_placement/util/DimensionBiomeList.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome_placement/util/DimensionBiomeList.kt
@@ -8,14 +8,14 @@ import net.minecraft.world.level.dimension.DimensionType
 
 data class DimensionBiomeList(
 	@JvmField var dimension: ResourceKey<DimensionType>,
-	@JvmField var biomes: List<BiomeParameters>
+	@JvmField var biomes: MutableList<BiomeParameters>
 ) {
 	companion object {
         @JvmField
 		val CODEC: Codec<DimensionBiomeList> = RecordCodecBuilder.create { instance ->
 			instance.group(
 				ResourceKey.codec(Registries.DIMENSION_TYPE).fieldOf("dimension").forGetter(DimensionBiomeList::dimension),
-				BiomeParameters.CODEC.listOf().fieldOf("biomes").forGetter(DimensionBiomeList::biomes)
+				BiomeParameters.CODEC.mutListOf().fieldOf("biomes").forGetter(DimensionBiomeList::biomes)
 			).apply(instance, ::DimensionBiomeList)
 		}
 	}

--- a/src/main/java/net/frozenblock/configurableeverything/biome_placement/util/DimensionBiomeList.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/biome_placement/util/DimensionBiomeList.kt
@@ -2,6 +2,7 @@ package net.frozenblock.configurableeverything.biome_placement.util
 
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceKey
 import net.minecraft.world.level.dimension.DimensionType

--- a/src/main/java/net/frozenblock/configurableeverything/config/BiomeConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/BiomeConfig.kt
@@ -19,24 +19,24 @@ import net.minecraft.sounds.Music
 import net.minecraft.sounds.SoundEvents
 import net.minecraft.world.level.levelgen.GenerationStep.Decoration
 
-private val BIOME_PLACED_FEATURE_LIST: TypedEntryType<List<BiomePlacedFeatureList>> = ConfigRegistry.register(
+private val BIOME_PLACED_FEATURE_LIST: TypedEntryType<MutableList<BiomePlacedFeatureList>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        BiomePlacedFeatureList.CODEC.listOf()
+        BiomePlacedFeatureList.CODEC.mutListOf()
     )
 )
 
-private val BIOME_PLACED_FEATURE_REPLACEMENT_LIST: TypedEntryType<List<BiomePlacedFeatureReplacementList>> = ConfigRegistry.register(
+private val BIOME_PLACED_FEATURE_REPLACEMENT_LIST: TypedEntryType<MutableList<BiomePlacedFeatureReplacementList>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        BiomePlacedFeatureReplacementList.CODEC.listOf()
+        BiomePlacedFeatureReplacementList.CODEC.mutListOf()
     )
 )
 
-private val BIOME_MUSIC_LIST: TypedEntryType<List<BiomeMusic>> = ConfigRegistry.register(
+private val BIOME_MUSIC_LIST: TypedEntryType<MutableList<BiomeMusic>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        BiomeMusic.CODEC.listOf()
+        BiomeMusic.CODEC.mutListOf()
     )
 )
 
@@ -44,15 +44,15 @@ private val BIOME_MUSIC_LIST: TypedEntryType<List<BiomeMusic>> = ConfigRegistry.
 data class BiomeConfig(
 	@JvmField
 	@EntrySyncData("addedFeatures")
-	var addedFeatures: TypedEntry<List<BiomePlacedFeatureList>> = TypedEntry.create(
+	var addedFeatures: TypedEntry<MutableList<BiomePlacedFeatureList>> = TypedEntry.create(
 		BIOME_PLACED_FEATURE_LIST,
-		listOf(
+		mutableListOf(
 			BiomePlacedFeatureList(
 				Either.left(BLANK_BIOME),
-				listOf(
+				mutableListOf(
 					DecorationStepPlacedFeature(
 						Decoration.VEGETAL_DECORATION,
-						listOf(
+						mutableListOf(
 							BLANK_PLACED_FEATURE
 						)
 					)
@@ -60,10 +60,10 @@ data class BiomeConfig(
 			),
 			BiomePlacedFeatureList(
 				Either.right(BLANK_TAG),
-				listOf(
+				mutableListOf(
 					DecorationStepPlacedFeature(
 						Decoration.VEGETAL_DECORATION,
-						listOf(
+						mutableListOf(
 							BLANK_PLACED_FEATURE
 						)
 					)
@@ -74,15 +74,15 @@ data class BiomeConfig(
 
 	@JvmField
 	@EntrySyncData("removedFeatures")
-	var removedFeatures: TypedEntry<List<BiomePlacedFeatureList>> = TypedEntry.create(
+	var removedFeatures: TypedEntry<MutableList<BiomePlacedFeatureList>> = TypedEntry.create(
 		BIOME_PLACED_FEATURE_LIST,
-		listOf(
+		mutableListOf(
 			BiomePlacedFeatureList(
 				Either.left(BLANK_BIOME),
-				listOf(
+				mutableListOf(
 					DecorationStepPlacedFeature(
 						Decoration.VEGETAL_DECORATION,
-						listOf(
+						mutableListOf(
 							BLANK_PLACED_FEATURE
 						)
 					)
@@ -90,10 +90,10 @@ data class BiomeConfig(
 			),
 			BiomePlacedFeatureList(
 				Either.right(BLANK_TAG),
-				listOf(
+				mutableListOf(
 					DecorationStepPlacedFeature(
 						Decoration.VEGETAL_DECORATION,
-						listOf(
+						mutableListOf(
 							BLANK_PLACED_FEATURE
 						)
 					)
@@ -104,17 +104,17 @@ data class BiomeConfig(
 
 	@JvmField
 	@EntrySyncData("replacedFeatures")
-	var replacedFeatures: TypedEntry<List<BiomePlacedFeatureReplacementList>> = TypedEntry.create(
+	var replacedFeatures: TypedEntry<MutableList<BiomePlacedFeatureReplacementList>> = TypedEntry.create(
 		BIOME_PLACED_FEATURE_REPLACEMENT_LIST,
-		listOf(
+		mutableListOf(
 			BiomePlacedFeatureReplacementList(
 				Either.left(BLANK_BIOME),
-				listOf(
+				mutableListOf(
 					PlacedFeatureReplacement(
 						BLANK_PLACED_FEATURE,
 						DecorationStepPlacedFeature(
 							Decoration.VEGETAL_DECORATION,
-							listOf(
+							mutableListOf(
 								BLANK_PLACED_FEATURE
 							)
 						)
@@ -123,12 +123,12 @@ data class BiomeConfig(
 			),
 			BiomePlacedFeatureReplacementList(
 				Either.right(BLANK_TAG),
-				listOf(
+				mutableListOf(
 					PlacedFeatureReplacement(
 						BLANK_PLACED_FEATURE,
 						DecorationStepPlacedFeature(
 							Decoration.VEGETAL_DECORATION,
-							listOf(
+							mutableListOf(
 								BLANK_PLACED_FEATURE
 							)
 						)
@@ -140,9 +140,9 @@ data class BiomeConfig(
 
 	@JvmField
 	@EntrySyncData("musicReplacements")
-	var musicReplacements: TypedEntry<List<BiomeMusic>> = TypedEntry.create(
+	var musicReplacements: TypedEntry<MutableList<BiomeMusic>> = TypedEntry.create(
 		BIOME_MUSIC_LIST,
-		listOf(
+		mutableListOf(
 			BiomeMusic(
 				Either.left(BLANK_BIOME),
 				Music(

--- a/src/main/java/net/frozenblock/configurableeverything/config/BiomePlacementConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/BiomePlacementConfig.kt
@@ -4,16 +4,13 @@ import com.mojang.datafixers.util.Either
 import net.frozenblock.configurableeverything.biome_placement.util.BiomeParameters
 import net.frozenblock.configurableeverything.biome_placement.util.DimensionBiomeKeyList
 import net.frozenblock.configurableeverything.biome_placement.util.DimensionBiomeList
-
 import net.frozenblock.configurableeverything.datagen.ConfigurableEverythingDataGenerator.Companion.BLANK_BIOME
 import net.frozenblock.configurableeverything.datagen.ConfigurableEverythingDataGenerator.Companion.BLANK_TAG
 import net.frozenblock.configurableeverything.util.CEConfig
-import net.frozenblock.configurableeverything.util.CONFIG_FORMAT
 import net.frozenblock.configurableeverything.util.MOD_ID
-import net.frozenblock.configurableeverything.util.makeConfigPath
+import net.frozenblock.configurableeverything.util.mutListOf
 import net.frozenblock.lib.config.api.entry.TypedEntry
 import net.frozenblock.lib.config.api.entry.TypedEntryType
-import net.frozenblock.lib.config.api.instance.xjs.XjsConfig
 import net.frozenblock.lib.config.api.registry.ConfigRegistry
 import net.frozenblock.lib.config.api.sync.annotation.EntrySyncData
 import net.frozenblock.lib.config.api.sync.annotation.UnsyncableConfig

--- a/src/main/java/net/frozenblock/configurableeverything/config/BiomePlacementConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/BiomePlacementConfig.kt
@@ -24,17 +24,17 @@ import net.minecraft.world.level.biome.Climate.Parameter.span
 import net.minecraft.world.level.biome.Climate.parameters
 import net.minecraft.world.level.dimension.BuiltinDimensionTypes
 
-private val BIOME_KEY_LIST: TypedEntryType<List<DimensionBiomeKeyList>> = ConfigRegistry.register(
+private val BIOME_KEY_LIST: TypedEntryType<MutableList<DimensionBiomeKeyList>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        DimensionBiomeKeyList.CODEC.listOf()
+        DimensionBiomeKeyList.CODEC.mutListOf()
     )
 )
 
-private val BIOME_PARAMETER_LIST: TypedEntryType<List<DimensionBiomeList>> = ConfigRegistry.register(
+private val BIOME_PARAMETER_LIST: TypedEntryType<MutableList<DimensionBiomeList>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        DimensionBiomeList.CODEC.listOf()
+        DimensionBiomeList.CODEC.mutListOf()
     )
 )
 
@@ -50,12 +50,12 @@ so replacing a biome's parameters is possible.
 Supports: Vanilla biomes, datapack biomes, modded biomes
 """
 	)
-	var addedBiomes: TypedEntry<List<DimensionBiomeList>> = TypedEntry.create(
+	var addedBiomes: TypedEntry<MutableList<DimensionBiomeList>> = TypedEntry.create(
 		BIOME_PARAMETER_LIST,
-		listOf(
+		mutableListOf(
 			DimensionBiomeList(
 				BuiltinDimensionTypes.OVERWORLD,
-				listOf(
+				mutableListOf(
 					BiomeParameters(
 						BLANK_BIOME.location(),
 						parameters(
@@ -72,7 +72,7 @@ Supports: Vanilla biomes, datapack biomes, modded biomes
 			),
 			DimensionBiomeList(
 				BuiltinDimensionTypes.NETHER,
-				listOf(
+				mutableListOf(
 					BiomeParameters(
 						BLANK_BIOME.location(),
 						parameters(
@@ -101,19 +101,19 @@ Supports: Vanilla biomes, datapack biomes, Vanilla biome tags, datapack biome ta
 Does not support biomes added via TerraBlender
 """
 	)
-	var removedBiomes: TypedEntry<List<DimensionBiomeKeyList>> = TypedEntry.create(
+	var removedBiomes: TypedEntry<MutableList<DimensionBiomeKeyList>> = TypedEntry.create(
 		BIOME_KEY_LIST,
-		listOf(
+		mutableListOf(
 			DimensionBiomeKeyList(
 				BuiltinDimensionTypes.OVERWORLD,
-				listOf(
+				mutableListOf(
 					Either.left(BLANK_BIOME),
 					Either.right(BLANK_TAG)
 				)
 			),
 			DimensionBiomeKeyList(
 				BuiltinDimensionTypes.NETHER,
-				listOf(
+				mutableListOf(
 					Either.left(BLANK_BIOME),
 					Either.right(BLANK_TAG)
 				)

--- a/src/main/java/net/frozenblock/configurableeverything/config/BlockConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/BlockConfig.kt
@@ -16,7 +16,7 @@ import net.frozenblock.lib.config.api.sync.annotation.EntrySyncData
 import net.frozenblock.lib.config.api.sync.annotation.UnsyncableConfig
 import net.minecraft.sounds.SoundEvents
 
-private val SOUND_GROUP_OVERWRITES: TypedEntryType<List<MutableBlockSoundGroupOverwrite>> = ConfigRegistry.register(
+private val SOUND_GROUP_OVERWRITES: TypedEntryType<MutableList<MutableBlockSoundGroupOverwrite>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
         Codec.list(MutableBlockSoundGroupOverwrite.CODEC)
@@ -27,9 +27,9 @@ private val SOUND_GROUP_OVERWRITES: TypedEntryType<List<MutableBlockSoundGroupOv
 data class BlockConfig(
     @JvmField
     @EntrySyncData(behavior = SyncBehavior.UNSYNCABLE)
-    var soundGroupOverwrites: TypedEntry<List<MutableBlockSoundGroupOverwrite>> = TypedEntry.create(
+    var soundGroupOverwrites: TypedEntry<MutableList<MutableBlockSoundGroupOverwrite>> = TypedEntry.create(
         SOUND_GROUP_OVERWRITES,
-        listOf(
+        mutableListOf(
             MutableBlockSoundGroupOverwrite(
                 vanillaId("grass_block"),
                 MutableSoundType(

--- a/src/main/java/net/frozenblock/configurableeverything/config/DataFixerConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/DataFixerConfig.kt
@@ -143,7 +143,7 @@ Each fixer contains an old id and a new id, and will replace all instances of th
 However, if the old id is still found in the registry, it will not be replaced (unless the overrideRealEntries option is set to true).
 """
     )
-    var registryFixers: TypedEntry<List<RegistryFixer>> = TypedEntry.create(
+    var registryFixers: TypedEntry<MutableList<RegistryFixer>> = TypedEntry.create(
         REGISTRY_FIXER_LIST,
         mutableListOf(
             RegistryFixer(

--- a/src/main/java/net/frozenblock/configurableeverything/config/DataFixerConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/DataFixerConfig.kt
@@ -9,6 +9,7 @@ import net.frozenblock.configurableeverything.util.CEConfig
 import net.frozenblock.configurableeverything.util.CONFIG_FORMAT
 import net.frozenblock.configurableeverything.util.MOD_ID
 import net.frozenblock.configurableeverything.util.makeConfigPath
+import net.frozenblock.configurableeverything.util.mutListOf
 import net.frozenblock.lib.config.api.entry.TypedEntry
 import net.frozenblock.lib.config.api.entry.TypedEntryType
 import net.frozenblock.lib.config.api.instance.xjs.XjsConfig
@@ -20,17 +21,17 @@ import net.frozenblock.lib.shadow.blue.endless.jankson.Comment
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceLocation
 
-private val SCHEMA_ENTRY_LIST: TypedEntryType<List<SchemaEntry>> = ConfigRegistry.register(
+private val SCHEMA_ENTRY_LIST: TypedEntryType<MutableList<SchemaEntry>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        Codec.list(SchemaEntry.CODEC)
+        SchemaEntry.CODEC.mutListOf()
     )
 )
 
-private val REGISTRY_FIXER_LIST: TypedEntryType<List<RegistryFixer>> = ConfigRegistry.register(
+private val REGISTRY_FIXER_LIST: TypedEntryType<MutableList<RegistryFixer>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        Codec.list(RegistryFixer.CODEC)
+        RegistryFixer.CODEC.mutListOf()
     )
 )
 
@@ -71,15 +72,15 @@ Each fixer contains an old id and a new id, and will replace all instances of th
 However, if the old id is still found in the registry, it will not be replaced.
 """
     )
-    var schemas: TypedEntry<List<SchemaEntry>> = TypedEntry.create(
+    var schemas: TypedEntry<MutableList<SchemaEntry>> = TypedEntry.create(
         SCHEMA_ENTRY_LIST,
-        listOf(
+        mutableListOf(
             SchemaEntry(
                 1,
-                listOf(
+                mutableListOf(
                     DataFixEntry(
                         "biome",
-                        listOf(
+                        mutableListOf(
                             Fixer(
                                 ResourceLocation("examplemod:example_biome"),
                                 ResourceLocation("minecraft:forest")
@@ -88,7 +89,7 @@ However, if the old id is still found in the registry, it will not be replaced.
                     ),
                     DataFixEntry(
                         "block",
-                        listOf(
+                        mutableListOf(
                             Fixer(
                                 ResourceLocation("examplemod:dark_stone"),
                                 ResourceLocation("minecraft:deepslate")
@@ -97,7 +98,7 @@ However, if the old id is still found in the registry, it will not be replaced.
                     ),
                     DataFixEntry(
                         "entity",
-                        listOf(
+                        mutableListOf(
                             Fixer(
                                 ResourceLocation("examplemod:example_entity"),
                                 ResourceLocation("minecraft:cow")
@@ -106,7 +107,7 @@ However, if the old id is still found in the registry, it will not be replaced.
                     ),
                     DataFixEntry(
                         "item",
-                        listOf(
+                        mutableListOf(
                             Fixer(
                                 ResourceLocation("examplemod:example_item"),
                                 ResourceLocation("minecraft:stone")
@@ -117,10 +118,10 @@ However, if the old id is still found in the registry, it will not be replaced.
             ),
             SchemaEntry(
                 2,
-                listOf(
+                mutableListOf(
                     DataFixEntry(
                         "block",
-                        listOf(
+                        mutableListOf(
                             Fixer(
                                 ResourceLocation("examplemod:old_block"),
                                 ResourceLocation("minecraft:grass_block")
@@ -144,10 +145,10 @@ However, if the old id is still found in the registry, it will not be replaced (
     )
     var registryFixers: TypedEntry<List<RegistryFixer>> = TypedEntry.create(
         REGISTRY_FIXER_LIST,
-        listOf(
+        mutableListOf(
             RegistryFixer(
                 Registries.BLOCK.location(),
-                listOf(
+                mutableListOf(
                     Fixer(
                         ResourceLocation("examplemod:example_block"),
                         ResourceLocation("minecraft:stone")
@@ -156,7 +157,7 @@ However, if the old id is still found in the registry, it will not be replaced (
             ),
             RegistryFixer(
                 Registries.ENTITY_TYPE.location(),
-                listOf(
+                mutableListOf(
                     Fixer(
                         ResourceLocation("examplemod:example_entity"),
                         ResourceLocation("minecraft:cow")
@@ -165,7 +166,7 @@ However, if the old id is still found in the registry, it will not be replaced (
             ),
             RegistryFixer(
                 Registries.ITEM.location(),
-                listOf(
+                mutableListOf(
                     Fixer(
                         ResourceLocation("examplemod:example_item"),
                         ResourceLocation("minecraft:stone")

--- a/src/main/java/net/frozenblock/configurableeverything/config/EntityConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/EntityConfig.kt
@@ -16,38 +16,38 @@ import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceKey
 import net.minecraft.resources.ResourceLocation
 
-private val ENTITY_ATTRIBUTE_AMPLIFIERS: TypedEntryType<List<EntityAttributeAmplifier>> = ConfigRegistry.register(
+private val ENTITY_ATTRIBUTE_AMPLIFIERS: TypedEntryType<MutableList<EntityAttributeAmplifier>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        EntityAttributeAmplifier.CODEC.listOf()
+        EntityAttributeAmplifier.CODEC.mutListOf()
     )
 )
 
-private val ENTITY_FLYBY_SOUNDS: TypedEntryType<List<EntityFlyBySound>> = ConfigRegistry.register(
+private val ENTITY_FLYBY_SOUNDS: TypedEntryType<MutableList<EntityFlyBySound>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        EntityFlyBySound.CODEC.listOf()
+        EntityFlyBySound.CODEC.mutListOf()
     )
 )
 
-private val ENTITY_HURT_EFFECTS: TypedEntryType<List<EntityHurtEffects>> = ConfigRegistry.register(
+private val ENTITY_HURT_EFFECTS: TypedEntryType<MutableList<EntityHurtEffects>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        EntityHurtEffects.CODEC.listOf()
+        EntityHurtEffects.CODEC.mutListOf()
     )
 )
 
-private val EXPERIENCE_OVERRIDES: TypedEntryType<List<ExperienceOverride>> = ConfigRegistry.register(
+private val EXPERIENCE_OVERRIDES: TypedEntryType<MutableList<ExperienceOverride>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        ExperienceOverride.CODEC.listOf()
+        ExperienceOverride.CODEC.mutListOf()
     )
 )
 
-private val SPOTTING_ICONS: TypedEntryType<List<EntitySpottingIcon>> = ConfigRegistry.register(
+private val SPOTTING_ICONS: TypedEntryType<MutableList<EntitySpottingIcon>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        EntitySpottingIcon.CODEC.listOf()
+        EntitySpottingIcon.CODEC.mutListOf()
     )
 )
 
@@ -55,13 +55,13 @@ private val SPOTTING_ICONS: TypedEntryType<List<EntitySpottingIcon>> = ConfigReg
 data class EntityConfig(
     @JvmField
     @EntrySyncData("entityAttributeAmplifiers")
-    var entityAttributeAmplifiers: TypedEntry<List<EntityAttributeAmplifier>> = TypedEntry.create(
+    var entityAttributeAmplifiers: TypedEntry<MutableList<EntityAttributeAmplifier>> = TypedEntry.create(
         ENTITY_ATTRIBUTE_AMPLIFIERS,
-        listOf(
+        mutableListOf(
             EntityAttributeAmplifier(
                 ResourceKey.create(Registries.ENTITY_TYPE, ResourceLocation("example")),
                 "",
-                listOf(
+                mutableListOf(
                     AttributeAmplifier(
                         ResourceKey.create(Registries.ATTRIBUTE, ResourceLocation("generic.movement_speed")),
                         1.5
@@ -73,9 +73,9 @@ data class EntityConfig(
 
     @JvmField
     @EntrySyncData("experienceOverrides")
-    var experienceOverrides: TypedEntry<List<ExperienceOverride>> = TypedEntry.create(
+    var experienceOverrides: TypedEntry<MutableList<ExperienceOverride>> = TypedEntry.create(
         EXPERIENCE_OVERRIDES,
-        listOf(
+        mutableListOf(
             ExperienceOverride(
                 ResourceKey.create(Registries.ENTITY_TYPE, ResourceLocation("example")),
                 5000
@@ -85,9 +85,9 @@ data class EntityConfig(
 
     @JvmField
     @EntrySyncData("entityFlyBySounds")
-    var entityFlyBySounds: TypedEntry<List<EntityFlyBySound>> = TypedEntry.create(
+    var entityFlyBySounds: TypedEntry<MutableList<EntityFlyBySound>> = TypedEntry.create(
         ENTITY_FLYBY_SOUNDS,
-        listOf(
+        mutableListOf(
             EntityFlyBySound(
                 ResourceLocation("minecraft:arrow"),
                 EntityFlyBySoundData(
@@ -174,13 +174,13 @@ data class EntityConfig(
 
     @JvmField
     @EntrySyncData("entityHurtEffects")
-    var entityHurtEffects: TypedEntry<List<EntityHurtEffects>> = TypedEntry.create(
+    var entityHurtEffects: TypedEntry<MutableList<EntityHurtEffects>> = TypedEntry.create(
         ENTITY_HURT_EFFECTS,
-        listOf(
+        mutableListOf(
             EntityHurtEffects(
                 ResourceLocation("cow"),
                 "",
-                listOf(
+                mutableListOf(
                     MobEffectHolder(
                         ResourceKey.create(Registries.MOB_EFFECT, ResourceLocation("speed")),
                         5,
@@ -196,9 +196,9 @@ data class EntityConfig(
 
     @JvmField
     @EntrySyncData(behavior = SyncBehavior.UNSYNCABLE)
-    var entitySpottingIcons: TypedEntry<List<EntitySpottingIcon>> = TypedEntry.create(
+    var entitySpottingIcons: TypedEntry<MutableList<EntitySpottingIcon>> = TypedEntry.create(
         SPOTTING_ICONS,
-        listOf(
+        mutableListOf(
             EntitySpottingIcon(
                 ResourceKey.create(Registries.ENTITY_TYPE, ResourceLocation("example")),
                 id("textures/spotting_icon/icon.png"),

--- a/src/main/java/net/frozenblock/configurableeverything/config/FluidConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/FluidConfig.kt
@@ -14,10 +14,10 @@ import net.frozenblock.lib.config.api.sync.annotation.UnsyncableConfig
 import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.world.level.material.Fluids
 
-private val FLUID_FLOW_SPEEDS: TypedEntryType<List<FluidFlowSpeed>> = ConfigRegistry.register(
+private val FLUID_FLOW_SPEEDS: TypedEntryType<MutableList<FluidFlowSpeed>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        FluidFlowSpeed.CODEC.listOf()
+        FluidFlowSpeed.CODEC.mutListOf()
     )
 )
 
@@ -25,9 +25,9 @@ private val FLUID_FLOW_SPEEDS: TypedEntryType<List<FluidFlowSpeed>> = ConfigRegi
 data class FluidConfig(
     @JvmField
     @EntrySyncData("flowSpeeds")
-    var flowSpeeds: TypedEntry<List<FluidFlowSpeed>> = TypedEntry.create(
+    var flowSpeeds: TypedEntry<MutableList<FluidFlowSpeed>> = TypedEntry.create(
         FLUID_FLOW_SPEEDS,
-        listOf(
+        mutableListOf(
             FluidFlowSpeed(
                 BuiltInRegistries.FLUID.getResourceKey(Fluids.WATER).orElseThrow(),
                 5,

--- a/src/main/java/net/frozenblock/configurableeverything/config/FluidConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/FluidConfig.kt
@@ -1,10 +1,8 @@
 package net.frozenblock.configurableeverything.config
 
 import net.frozenblock.configurableeverything.fluid.util.FluidFlowSpeed
-import net.frozenblock.configurableeverything.util.CEConfig
-import net.frozenblock.configurableeverything.util.CONFIG_FORMAT
+import net.frozenblock.configurableeverything.util.*
 import net.frozenblock.configurableeverything.util.MOD_ID
-import net.frozenblock.configurableeverything.util.makeConfigPath
 import net.frozenblock.lib.config.api.entry.TypedEntry
 import net.frozenblock.lib.config.api.entry.TypedEntryType
 import net.frozenblock.lib.config.api.instance.xjs.XjsConfig

--- a/src/main/java/net/frozenblock/configurableeverything/config/GravityConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/GravityConfig.kt
@@ -16,10 +16,10 @@ import net.frozenblock.lib.gravity.api.functions.AbsoluteGravityFunction
 import net.minecraft.world.level.Level
 import net.minecraft.world.phys.Vec3
 
-private val DIMENSION_GRAVITY_BELT_LIST: TypedEntryType<List<DimensionGravityBelt>> = ConfigRegistry.register(
+private val DIMENSION_GRAVITY_BELT_LIST: TypedEntryType<MutableList<DimensionGravityBelt>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        DimensionGravityBelt.CODEC.listOf()
+        DimensionGravityBelt.CODEC.mutListOf()
     )
 )
 
@@ -27,12 +27,12 @@ private val DIMENSION_GRAVITY_BELT_LIST: TypedEntryType<List<DimensionGravityBel
 data class GravityConfig(
     @JvmField
     @EntrySyncData("gravityBelts")
-    var gravityBelts: TypedEntry<List<DimensionGravityBelt>> = TypedEntry.create(
+    var gravityBelts: TypedEntry<MutableList<DimensionGravityBelt>> = TypedEntry.create(
         DIMENSION_GRAVITY_BELT_LIST,
-        listOf(
+        mutableListOf(
             DimensionGravityBelt(
                 Level.OVERWORLD,
-                listOf(
+                mutableListOf(
                     GravityBelt(128.0, 319.0, AbsoluteGravityFunction(Vec3(0.0, 0.1, 0.0))),
                     GravityBelt(500.0, Double.POSITIVE_INFINITY, AbsoluteGravityFunction(Vec3(0.0, 0.01, 0.0)))
                 )

--- a/src/main/java/net/frozenblock/configurableeverything/config/GravityConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/GravityConfig.kt
@@ -1,10 +1,8 @@
 package net.frozenblock.configurableeverything.config
 
 import net.frozenblock.configurableeverything.gravity.util.DimensionGravityBelt
-import net.frozenblock.configurableeverything.util.CEConfig
-import net.frozenblock.configurableeverything.util.CONFIG_FORMAT
+import net.frozenblock.configurableeverything.util.*
 import net.frozenblock.configurableeverything.util.MOD_ID
-import net.frozenblock.configurableeverything.util.makeConfigPath
 import net.frozenblock.lib.config.api.entry.TypedEntry
 import net.frozenblock.lib.config.api.entry.TypedEntryType
 import net.frozenblock.lib.config.api.instance.xjs.XjsConfig

--- a/src/main/java/net/frozenblock/configurableeverything/config/ItemConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/ItemConfig.kt
@@ -15,7 +15,7 @@ import net.frozenblock.lib.config.api.sync.annotation.UnsyncableConfig
 import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.world.item.Items
 
-private val ITEM_REACH_OVERRIDES: TypedEntryType<List<ItemReachOverride>> = ConfigRegistry.register(
+private val ITEM_REACH_OVERRIDES: TypedEntryType<MutableList<ItemReachOverride>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
         Codec.list(ItemReachOverride.CODEC)
@@ -26,9 +26,9 @@ private val ITEM_REACH_OVERRIDES: TypedEntryType<List<ItemReachOverride>> = Conf
 data class ItemConfig(
     @JvmField
     @EntrySyncData("reachOverrides")
-    var reachOverrides: TypedEntry<List<ItemReachOverride>> = TypedEntry.create(
+    var reachOverrides: TypedEntry<MutableList<ItemReachOverride>> = TypedEntry.create(
         ITEM_REACH_OVERRIDES,
-        listOf(
+        mutableListOf(
             ItemReachOverride(
                 BuiltInRegistries.ITEM.getKey(Items.TRIDENT),
                 100.0

--- a/src/main/java/net/frozenblock/configurableeverything/config/LootConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/LootConfig.kt
@@ -19,7 +19,7 @@ import net.minecraft.world.level.storage.loot.entries.LootItem
 import net.minecraft.world.level.storage.loot.functions.SetItemCountFunction
 import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator
 
-private val LOOT_MODIFICATIONS: TypedEntryType<List<LootModification>> = ConfigRegistry.register(
+private val LOOT_MODIFICATIONS: TypedEntryType<MutableList<LootModification>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
         Codec.list(LootModification.CODEC)
@@ -30,9 +30,9 @@ private val LOOT_MODIFICATIONS: TypedEntryType<List<LootModification>> = ConfigR
 data class LootConfig(
     @JvmField
     @EntrySyncData("lootModifications")
-    var lootModifications: TypedEntry<List<LootModification>> = TypedEntry.create(
+    var lootModifications: TypedEntry<MutableList<LootModification>> = TypedEntry.create(
         LOOT_MODIFICATIONS,
-        listOf(
+        mutableListOf(
             LootModification(
                 BuiltInLootTables.ANCIENT_CITY.location(),
                 LootPool.lootPool()
@@ -42,7 +42,7 @@ data class LootConfig(
                             .apply(SetItemCountFunction.setCount(UniformGenerator.between(1F, 64F)))
                     )
                     .build(),
-                listOf()
+                mutableListOf()
             )
         )
     )

--- a/src/main/java/net/frozenblock/configurableeverything/config/RegistryConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/RegistryConfig.kt
@@ -18,17 +18,17 @@ import net.minecraft.world.level.biome.BiomeGenerationSettings
 import net.minecraft.world.level.biome.BiomeSpecialEffects
 import net.minecraft.world.level.biome.MobSpawnSettings
 
-private val BIOME_ADDITIONS: TypedEntryType<List<BiomeAddition>> = ConfigRegistry.register(
+private val BIOME_ADDITIONS: TypedEntryType<MutableList<BiomeAddition>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        BiomeAddition.CODEC.listOf()
+        BiomeAddition.CODEC.mutListOf()
     )
 )
 
-private val PLACED_FEATURE_ADDITIONS: TypedEntryType<List<PlacedFeatureAddition>> = ConfigRegistry.register(
+private val PLACED_FEATURE_ADDITIONS: TypedEntryType<MutableList<PlacedFeatureAddition>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        PlacedFeatureAddition.CODEC.listOf()
+        PlacedFeatureAddition.CODEC.mutListOf()
     )
 )
 
@@ -37,9 +37,9 @@ data class RegistryConfig(
     @JvmField
     @EntrySyncData("biomeAdditions")
     @Comment("Adds these biomes to the biome registry on datapack load.")
-    var biomeAdditions: TypedEntry<List<BiomeAddition>> = TypedEntry.create(
+    var biomeAdditions: TypedEntry<MutableList<BiomeAddition>> = TypedEntry.create(
         BIOME_ADDITIONS,
-        listOf(
+        mutableListOf(
             BiomeAddition(
                 id("example"),
                 // copy of blank biome
@@ -67,9 +67,9 @@ data class RegistryConfig(
     @JvmField
     @EntrySyncData("placedFeatureAdditions")
     @Comment("Adds these placed features to the placed feature registry on datapack load.")
-    var placedFeatureAdditions: TypedEntry<List<PlacedFeatureAddition>> = TypedEntry.create(
+    var placedFeatureAdditions: TypedEntry<MutableList<PlacedFeatureAddition>> = TypedEntry.create(
         PLACED_FEATURE_ADDITIONS,
-        listOf() // cant make an example bc it requires a holder and the registry is dynamic
+        mutableListOf() // cant make an example bc it requires a holder and the registry is dynamic
     )
 ) {
     companion object : CEConfig<RegistryConfig>(

--- a/src/main/java/net/frozenblock/configurableeverything/config/ScreenShakeConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/ScreenShakeConfig.kt
@@ -15,10 +15,10 @@ import net.frozenblock.lib.config.api.sync.annotation.UnsyncableConfig
 import net.minecraft.sounds.SoundEvents
 import net.minecraft.world.entity.monster.warden.WardenAi
 
-private val SOUND_SCREEN_SHAKE : TypedEntryType<List<SoundScreenShake>> = ConfigRegistry.register(
+private val SOUND_SCREEN_SHAKE : TypedEntryType<MutableList<SoundScreenShake>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        SoundScreenShake.CODEC.listOf()
+        SoundScreenShake.CODEC.mutListOf()
     )
 )
 
@@ -26,9 +26,9 @@ private val SOUND_SCREEN_SHAKE : TypedEntryType<List<SoundScreenShake>> = Config
 data class ScreenShakeConfig(
     @JvmField
     @EntrySyncData(behavior = SyncBehavior.UNSYNCABLE)
-    var soundScreenShakes: TypedEntry<List<SoundScreenShake>> = TypedEntry.create(
+    var soundScreenShakes: TypedEntry<MutableList<SoundScreenShake>> = TypedEntry.create(
         SOUND_SCREEN_SHAKE,
-        listOf(
+        mutableListOf(
             SoundScreenShake(
                 SoundEvents.ENDER_DRAGON_GROWL.location,
                 2.5f,

--- a/src/main/java/net/frozenblock/configurableeverything/config/ScreenShakeConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/ScreenShakeConfig.kt
@@ -1,10 +1,8 @@
 package net.frozenblock.configurableeverything.config
 
 import net.frozenblock.configurableeverything.screenshake.util.SoundScreenShake
-import net.frozenblock.configurableeverything.util.CEConfig
-import net.frozenblock.configurableeverything.util.CONFIG_FORMAT
+import net.frozenblock.configurableeverything.util.*
 import net.frozenblock.configurableeverything.util.MOD_ID
-import net.frozenblock.configurableeverything.util.makeConfigPath
 import net.frozenblock.lib.config.api.entry.TypedEntry
 import net.frozenblock.lib.config.api.entry.TypedEntryType
 import net.frozenblock.lib.config.api.instance.xjs.XjsConfig

--- a/src/main/java/net/frozenblock/configurableeverything/config/SculkSpreadingConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/SculkSpreadingConfig.kt
@@ -1,10 +1,8 @@
 package net.frozenblock.configurableeverything.config
 
 import net.frozenblock.configurableeverything.sculk_spreading.util.SculkGrowth
-import net.frozenblock.configurableeverything.util.CEConfig
-import net.frozenblock.configurableeverything.util.CONFIG_FORMAT
+import net.frozenblock.configurableeverything.util.*
 import net.frozenblock.configurableeverything.util.MOD_ID
-import net.frozenblock.configurableeverything.util.makeConfigPath
 import net.frozenblock.lib.config.api.entry.TypedEntry
 import net.frozenblock.lib.config.api.entry.TypedEntryType
 import net.frozenblock.lib.config.api.instance.xjs.XjsConfig

--- a/src/main/java/net/frozenblock/configurableeverything/config/SculkSpreadingConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/SculkSpreadingConfig.kt
@@ -15,10 +15,10 @@ import net.frozenblock.lib.shadow.blue.endless.jankson.Comment
 import net.minecraft.world.level.block.Blocks
 import net.minecraft.world.level.block.SculkShriekerBlock
 
-private val SCULK_GROWTH_LIST: TypedEntryType<List<SculkGrowth>> = ConfigRegistry.register(
+private val SCULK_GROWTH_LIST: TypedEntryType<MutableList<SculkGrowth>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        SculkGrowth.CODEC.listOf()
+        SculkGrowth.CODEC.mutListOf()
     )
 )
 
@@ -28,7 +28,7 @@ data class SculkSpreadingConfig(
     @JvmField
     @EntrySyncData("activators")
     @Comment("List of growth block states.")
-    var growths: TypedEntry<List<SculkGrowth>> = TypedEntry.create(
+    var growths: TypedEntry<MutableList<SculkGrowth>> = TypedEntry.create(
         SCULK_GROWTH_LIST,
         arrayListOf(
             SculkGrowth(true, 11, Blocks.SCULK_SHRIEKER.defaultBlockState().setValue(SculkShriekerBlock.CAN_SUMMON, true)),

--- a/src/main/java/net/frozenblock/configurableeverything/config/SplashTextConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/SplashTextConfig.kt
@@ -21,13 +21,13 @@ data class SplashTextConfig(
 
     @JvmField
     @EntrySyncData(behavior = SyncBehavior.UNSYNCABLE)
-    var addedSplashes: List<String> = arrayListOf(
+    var addedSplashes: MutableList<String> = arrayListOf(
         "Configurable Everything!"
     ),
 
     @JvmField
     @EntrySyncData(behavior = SyncBehavior.UNSYNCABLE)
-    var removedSplashes: List<String> = arrayListOf(
+    var removedSplashes: MutableList<String> = arrayListOf(
         "random splash text"
     ),
 

--- a/src/main/java/net/frozenblock/configurableeverything/config/StructureConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/StructureConfig.kt
@@ -1,9 +1,7 @@
 package net.frozenblock.configurableeverything.config
 
-import net.frozenblock.configurableeverything.util.CEConfig
-import net.frozenblock.configurableeverything.util.CONFIG_FORMAT
+import net.frozenblock.configurableeverything.util.*
 import net.frozenblock.configurableeverything.util.MOD_ID
-import net.frozenblock.configurableeverything.util.makeConfigPath
 import net.frozenblock.lib.config.api.entry.TypedEntry
 import net.frozenblock.lib.config.api.entry.TypedEntryType
 import net.frozenblock.lib.config.api.instance.xjs.XjsConfig

--- a/src/main/java/net/frozenblock/configurableeverything/config/StructureConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/StructureConfig.kt
@@ -12,10 +12,10 @@ import net.frozenblock.lib.config.api.sync.annotation.EntrySyncData
 import net.frozenblock.lib.config.api.sync.annotation.UnsyncableConfig
 import net.minecraft.resources.ResourceLocation
 
-private val RESOURCE_LIST: TypedEntryType<List<ResourceLocation>> = ConfigRegistry.register(
+private val RESOURCE_LIST: TypedEntryType<MutableList<ResourceLocation>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        ResourceLocation.CODEC.listOf()
+        ResourceLocation.CODEC.mutListOf()
     )
 )
 
@@ -24,9 +24,9 @@ data class StructureConfig(
 
     @JvmField
     @EntrySyncData("removedStructures")
-    var removedStructures: TypedEntry<List<ResourceLocation>> = TypedEntry.create(
+    var removedStructures: TypedEntry<MutableList<ResourceLocation>> = TypedEntry.create(
         RESOURCE_LIST,
-        listOf(
+        mutableListOf(
             ResourceLocation("ancient_city"),
             ResourceLocation("village_plains")
         )
@@ -34,9 +34,9 @@ data class StructureConfig(
 
     @JvmField
     @EntrySyncData("removedStructureSets")
-    var removedStructureSets: TypedEntry<List<ResourceLocation>> = TypedEntry.create(
+    var removedStructureSets: TypedEntry<MutableList<ResourceLocation>> = TypedEntry.create(
         RESOURCE_LIST,
-        listOf(
+        mutableListOf(
             ResourceLocation("villages")
         )
     )

--- a/src/main/java/net/frozenblock/configurableeverything/config/SurfaceRuleConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/SurfaceRuleConfig.kt
@@ -1,10 +1,8 @@
 package net.frozenblock.configurableeverything.config
 
 import net.frozenblock.configurableeverything.datagen.ConfigurableEverythingDataGenerator
-import net.frozenblock.configurableeverything.util.CEConfig
-import net.frozenblock.configurableeverything.util.CONFIG_FORMAT
+import net.frozenblock.configurableeverything.util.*
 import net.frozenblock.configurableeverything.util.MOD_ID
-import net.frozenblock.configurableeverything.util.makeConfigPath
 import net.frozenblock.lib.config.api.entry.TypedEntry
 import net.frozenblock.lib.config.api.entry.TypedEntryType
 import net.frozenblock.lib.config.api.instance.xjs.XjsConfig

--- a/src/main/java/net/frozenblock/configurableeverything/config/SurfaceRuleConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/SurfaceRuleConfig.kt
@@ -16,10 +16,10 @@ import net.minecraft.world.level.block.Blocks
 import net.minecraft.world.level.dimension.BuiltinDimensionTypes
 import net.minecraft.world.level.levelgen.SurfaceRules
 
-private val SURFACE_RULE_LIST: TypedEntryType<List<FrozenDimensionBoundRuleSource>> = ConfigRegistry.register(
+private val SURFACE_RULE_LIST: TypedEntryType<MutableList<FrozenDimensionBoundRuleSource>> = ConfigRegistry.register(
     TypedEntryType(
         MOD_ID,
-        FrozenDimensionBoundRuleSource.CODEC.listOf()
+        FrozenDimensionBoundRuleSource.CODEC.mutListOf()
     )
 )
 
@@ -27,9 +27,9 @@ private val SURFACE_RULE_LIST: TypedEntryType<List<FrozenDimensionBoundRuleSourc
 data class SurfaceRuleConfig(
     @JvmField
     @EntrySyncData("addedSurfaceRules")
-    var addedSurfaceRules: TypedEntry<List<FrozenDimensionBoundRuleSource>> = TypedEntry.create(
+    var addedSurfaceRules: TypedEntry<MutableList<FrozenDimensionBoundRuleSource>> = TypedEntry.create(
         SURFACE_RULE_LIST,
-        listOf(
+        mutableListOf(
             FrozenDimensionBoundRuleSource(
                 BuiltinDimensionTypes.OVERWORLD.location(),
                 SurfaceRules.sequence(

--- a/src/main/java/net/frozenblock/configurableeverything/config/TagConfig.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/TagConfig.kt
@@ -28,16 +28,16 @@ data class TagConfig(
     @EntrySyncData("lootModifications")
     var tagModifications: TypedEntry<List<RegistryTagModification>> = TypedEntry.create(
         TAG_MODIFICATIONS,
-        listOf(
+        mutableListOf(
             RegistryTagModification(
                 BuiltInRegistries.BLOCK.key().location().toString(),
-                listOf(
+                mutableListOf(
                     TagModification(
                         "minecraft:piglin_loved",
-                        listOf(
+                        mutableListOf(
                             "diamond_block"
                         ),
-                        listOf(
+                        mutableListOf(
                             "gold_ingot"
                         )
                     )

--- a/src/main/java/net/frozenblock/configurableeverything/config/gui/BiomeConfigGui.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/gui/BiomeConfigGui.kt
@@ -19,8 +19,6 @@ import net.frozenblock.configurableeverything.util.text
 import net.frozenblock.configurableeverything.util.tooltip
 import net.frozenblock.lib.config.api.client.gui.EntryBuilder
 import net.frozenblock.lib.config.api.client.gui.multiElementEntry
-import net.frozenblock.lib.config.api.client.gui.nestedList
-import net.frozenblock.lib.config.api.client.gui.typedEntryList
 import net.frozenblock.lib.config.api.instance.Config
 import net.frozenblock.lib.config.clothconfig.synced
 import net.frozenblock.lib.sound.api.MutableMusic
@@ -123,7 +121,7 @@ private fun replacedFeatures(
             val defaultOriginal: ResourceKey<PlacedFeature> = BLANK_PLACED_FEATURE
             val defaultDecoration: Decoration = Decoration.VEGETAL_DECORATION
             val defaultReplacement: ResourceKey<PlacedFeature> = BLANK_PLACED_FEATURE
-            val defaultReplacements = listOf(defaultReplacement)
+            val defaultReplacements = mutableListOf(defaultReplacement)
             val defaultDecorationFeature = DecorationStepPlacedFeature(
                 defaultDecoration,
                 defaultReplacements
@@ -132,7 +130,7 @@ private fun replacedFeatures(
                 defaultOriginal,
                 defaultDecorationFeature
             )
-            val defaultReplacementFeatures = listOf(defaultReplacementFeature)
+            val defaultReplacementFeatures = mutableListOf(defaultReplacementFeature)
             val biomeReplacementList = element ?: BiomePlacedFeatureReplacementList(
                 defaultBiome,
                 defaultReplacementFeatures
@@ -191,7 +189,7 @@ private fun replacedFeatures(
 
                                 entryBuilder.startStrList(text("replaced_features.placed_features"), placedFeatures.map { key -> key.toStr() })
                                     .setDefaultValue(defaultReplacements.map { key -> key.toStr() })
-                                    .setSaveConsumer { newValue -> replacement.placedFeatures = newValue.map { it.toKey(Registries.PLACED_FEATURE) } }
+                                    .setSaveConsumer { newValue -> replacement.placedFeatures = newValue.map { it.toKey(Registries.PLACED_FEATURE) }.toMutableList() }
                                     .setTooltip(tooltip("replaced_features.placed_features"))
                                     .requireRestart()
                                     .build()
@@ -308,12 +306,12 @@ private fun biomePlacedFeaturesElement(
     val defaultBiome: Either<ResourceKey<Biome>, TagKey<Biome>> = Either.left(BLANK_BIOME)
     val defaultDecoration = Decoration.VEGETAL_DECORATION
     val defaultPlacedFeature = BLANK_PLACED_FEATURE
-    val defaultPlacedFeatures = listOf(defaultPlacedFeature)
+    val defaultPlacedFeatures = mutableListOf(defaultPlacedFeature)
     val defaultFeature = DecorationStepPlacedFeature(
         defaultDecoration,
         defaultPlacedFeatures
     )
-    val defaultFeatures = listOf(defaultFeature)
+    val defaultFeatures = mutableListOf(defaultFeature)
     val biomePlacedFeatureList: BiomePlacedFeatureList = element ?: BiomePlacedFeatureList(
         defaultBiome,
         defaultFeatures
@@ -356,7 +354,7 @@ private fun biomePlacedFeaturesElement(
 
                     entryBuilder.startStrList(text("$`lang`_features.placed_features"), placedFeatures.map { key -> key?.location().toString() })
                         .setDefaultValue(defaultPlacedFeatures.map { key -> key.location().toString() })
-                        .setSaveConsumer { newValue -> decorationFeature.placedFeatures = newValue.map { it.toKey(Registries.PLACED_FEATURE) } }
+                        .setSaveConsumer { newValue -> decorationFeature.placedFeatures = newValue.map { it.toKey(Registries.PLACED_FEATURE) }.toMutableList() }
                         .setTooltip(tooltip("$`lang`_features.placed_features"))
                         .requireRestart()
                         .build()

--- a/src/main/java/net/frozenblock/configurableeverything/config/gui/BiomePlacementConfigGui.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/gui/BiomePlacementConfigGui.kt
@@ -20,8 +20,6 @@ import net.frozenblock.configurableeverything.util.text
 import net.frozenblock.configurableeverything.util.tooltip
 import net.frozenblock.lib.config.api.client.gui.EntryBuilder
 import net.frozenblock.lib.config.api.client.gui.multiElementEntry
-import net.frozenblock.lib.config.api.client.gui.nestedList
-import net.frozenblock.lib.config.api.client.gui.typedEntryList
 import net.frozenblock.lib.config.api.instance.Config
 import net.frozenblock.lib.config.clothconfig.synced
 import net.frozenblock.lib.worldgen.biome.api.MutableParameter
@@ -68,7 +66,7 @@ private fun addedBiomes(
         tooltip("added_biomes"),
         { newValue -> config.addedBiomes = newValue },
         { element: DimensionBiomeList?, _ ->
-            val defaultParameters = listOf(
+            val defaultParameters = mutableListOf(
                 BiomeParameters(
                     ResourceLocation(""),
                     Climate.parameters(
@@ -225,7 +223,7 @@ private fun removedBiomes(
         tooltip("removed_biomes"),
         { newValue -> config.removedBiomes = newValue },
         { element: DimensionBiomeKeyList?, _ ->
-            val defaultBiomes: List<Either<ResourceKey<Biome>, TagKey<Biome>>> = listOf(
+            val defaultBiomes: MutableList<Either<ResourceKey<Biome>, TagKey<Biome>>> = mutableListOf(
                 Either.left(ConfigurableEverythingDataGenerator.BLANK_BIOME),
                 Either.right(ConfigurableEverythingDataGenerator.BLANK_TAG)
             )
@@ -249,7 +247,7 @@ private fun removedBiomes(
                 )
                     .setDefaultValue(defaultBiomes.map { either -> either.toStr() })
                     .setSaveConsumer { newValue ->
-                        dimensionBiomeList.biomes = newValue.map { it.toEitherKeyOrTag(Registries.BIOME) }
+                        dimensionBiomeList.biomes = newValue.map { it.toEitherKeyOrTag(Registries.BIOME) }.toMutableList()
                     }
                     .setTooltip(tooltip("removed_biomes.biomes"))
                     .build()

--- a/src/main/java/net/frozenblock/configurableeverything/config/gui/ConfigGuiUtil.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/gui/ConfigGuiUtil.kt
@@ -22,10 +22,10 @@ fun <T : Any> Either<ResourceKey<T>, TagKey<T>>?.toStr(): String {
     return string
 }
 
-fun <T : Any> String.toKey(registry: ResourceKey<out Registry<T>>): ResourceKey<T> = ResourceKey.create(registry, ResourceLocation(this))
+inline fun <T : Any> String.toKey(registry: ResourceKey<out Registry<T>>): ResourceKey<T> = ResourceKey.create(registry, ResourceLocation(this))
 
-fun <T : Any> ResourceKey<T>?.toStr(): String = this?.location()?.toString() ?: ""
+inline fun <T : Any> ResourceKey<T>?.toStr(): String = this?.location()?.toString() ?: ""
 
-fun <T : Any> String.toHolder(registry: Registry<T>): Holder<T>? = registry.getHolder(this.toKey(registry.key())).getOrNull()
+inline fun <T : Any> String.toHolder(registry: Registry<T>): Holder<T>? = registry.getHolder(this.toKey(registry.key())).getOrNull()
 
-fun <T : Any> Holder<T>.toStr(): String = this.unwrapKey().getOrNull()?.toStr() ?: ""
+inline fun <T : Any> Holder<T>.toStr(): String = this.unwrapKey().getOrNull()?.toStr() ?: ""

--- a/src/main/java/net/frozenblock/configurableeverything/config/gui/ConfigGuiUtil.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/gui/ConfigGuiUtil.kt
@@ -1,6 +1,7 @@
 package net.frozenblock.configurableeverything.config.gui
 
 import com.mojang.datafixers.util.Either
+import net.frozenblock.lib.config.api.client.gui.*;
 import net.minecraft.core.Holder
 import net.minecraft.core.Registry
 import net.minecraft.resources.ResourceKey
@@ -29,3 +30,29 @@ inline fun <T : Any> ResourceKey<T>?.toStr(): String = this?.location()?.toStrin
 inline fun <T : Any> String.toHolder(registry: Registry<T>): Holder<T>? = registry.getHolder(this.toKey(registry.key())).getOrNull()
 
 inline fun <T : Any> Holder<T>.toStr(): String = this.unwrapKey().getOrNull()?.toStr() ?: ""
+
+inline fun <T> typedEntryList(
+    entryBuilder: ConfigEntryBuilder,
+    title: Component,
+    entrySupplier: (() -> TypedEntry<MutableList<T>>?)?,
+    defaultValue: () -> TypedEntry<MutableList<T>>,
+    expandedByDefault: Boolean = false,
+    tooltip: Component,
+    setterConsumer: (TypedEntry<MutableList<T>>) -> Unit,
+    cellCreator: (T, NestedListListEntry<T, AbstractConfigListEntry<T>>) -> AbstractConfigListEntry<T>,
+    requiresRestart: Boolean = false,
+    requirement: Requirement? = null
+): NestedListListEntry<T, AbstractConfigListEntry<T>> {
+    return typedEntryList(
+        entryBuilder,
+        title,
+        Supplier { entrySupplier() } as Supplier<TypedEntry<List<T>>?>?,
+        Supplier { defaultValue() } as Supplier<TypedEntry<List<T>>>,
+        expandedByDefault,
+        tooltip,
+        Consumer { list -> setterConsumer(list.toMutableList()) },
+        BiFunction { a, b -> cellCreator(a, b) },
+        requiresRestart,
+        requirement
+    )
+}

--- a/src/main/java/net/frozenblock/configurableeverything/config/gui/DataFixerConfigGui.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/gui/DataFixerConfigGui.kt
@@ -1,4 +1,5 @@
 @file:Environment(EnvType.CLIENT)
+@file:Suppress("UnstableApiUsage", "COMPATIBILITY_WARNING")
 
 package net.frozenblock.configurableeverything.config.gui
 
@@ -20,8 +21,6 @@ import net.frozenblock.configurableeverything.util.text
 import net.frozenblock.configurableeverything.util.tooltip
 import net.frozenblock.lib.config.api.client.gui.EntryBuilder
 import net.frozenblock.lib.config.api.client.gui.multiElementEntry
-import net.frozenblock.lib.config.api.client.gui.nestedList
-import net.frozenblock.lib.config.api.client.gui.typedEntryList
 import net.frozenblock.lib.config.clothconfig.synced
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceLocation
@@ -72,10 +71,10 @@ private fun schemas(
     defaultConfig: DataFixerConfig,
     dataVersion: IntegerListEntry
 ): AbstractConfigListEntry<*> {
-    val defaultFixEntryList = listOf(
+    val defaultFixEntryList = mutableListOf(
         DataFixEntry(
             "biome",
-            listOf(
+            mutableListOf(
                 Fixer(
                     ResourceLocation("example:example"),
                     ResourceLocation("minecraft:forest")
@@ -84,7 +83,7 @@ private fun schemas(
         ),
         DataFixEntry(
             "block",
-            listOf(
+            mutableListOf(
                 Fixer(
                     ResourceLocation("example:example"),
                     ResourceLocation("minecraft:deepslate")
@@ -93,7 +92,7 @@ private fun schemas(
         ),
         DataFixEntry(
             "entity",
-            listOf(
+            mutableListOf(
                 Fixer(
                     ResourceLocation("example:example"),
                     ResourceLocation("minecraft:cow")
@@ -102,7 +101,7 @@ private fun schemas(
         ),
         DataFixEntry(
             "item",
-            listOf(
+            mutableListOf(
                 Fixer(
                     ResourceLocation("example:example"),
                     ResourceLocation("minecraft:stone")
@@ -115,7 +114,7 @@ private fun schemas(
         entryBuilder,
         text("schemas"),
         config::schemas,
-        { defaultConfig.schemas!! },
+        { defaultConfig.schemas },
         false,
         tooltip("schemas"),
         { newValue -> config.schemas = newValue },
@@ -161,7 +160,7 @@ private fun schemas(
                                 entryBuilder,
                                 text("datafixer.fixers"),
                                 entry::fixers,
-                                { listOf(Fixer(ResourceLocation(""), ResourceLocation(""))) },
+                                { mutableListOf(Fixer(ResourceLocation(""), ResourceLocation(""))) },
                                 true,
                                 tooltip("datafixer.fixers"),
                                 { newValue -> entry.fixers = newValue },
@@ -216,7 +215,7 @@ private fun registryFixers(
     config: DataFixerConfig,
     defaultConfig: DataFixerConfig
 ): AbstractConfigListEntry<*> {
-    val defaultFixers = listOf(
+    val defaultFixers = mutableListOf(
         Fixer(
             ResourceLocation("examplemod:example_block"),
             ResourceLocation("minecraft:stone")

--- a/src/main/java/net/frozenblock/configurableeverything/config/gui/EntityConfigGui.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/gui/EntityConfigGui.kt
@@ -1,4 +1,5 @@
 @file:Environment(EnvType.CLIENT)
+@file:Suppress("UnstableApiUsage")
 
 package net.frozenblock.configurableeverything.config.gui
 
@@ -195,7 +196,7 @@ private fun entityAttributeAmplifiers(
         { newValue -> config.entityAttributeAmplifiers = newValue},
         { element: EntityAttributeAmplifier?, _ ->
             val defaultEntity = ResourceKey.create(Registries.ENTITY_TYPE, ResourceLocation(""))
-            val entityAttributeAmplifier = element ?: EntityAttributeAmplifier(defaultEntity, "", listOf(AttributeAmplifier(ResourceKey.create(Registries.ATTRIBUTE, ResourceLocation("")), 1.5)))
+            val entityAttributeAmplifier = element ?: EntityAttributeAmplifier(defaultEntity, "", mutableListOf(AttributeAmplifier(ResourceKey.create(Registries.ATTRIBUTE, ResourceLocation("")), 1.5)))
             multiElementEntry(
                 text("entity_attribute_amplifiers.entity_attribute_amplifier"),
                 entityAttributeAmplifier,
@@ -217,12 +218,11 @@ private fun entityAttributeAmplifiers(
                     entryBuilder,
                     text("entity_attribute_amplifiers.amplifiers"),
                     entityAttributeAmplifier::amplifiers,
-                    { listOf(AttributeAmplifier(ResourceKey.create(Registries.ATTRIBUTE, ResourceLocation("minecraft:generic.movement_speed")), 1.0)) },
+                    { mutableListOf(AttributeAmplifier(ResourceKey.create(Registries.ATTRIBUTE, ResourceLocation("minecraft:generic.movement_speed")), 1.0)) },
                     true,
                     tooltip("entity_attribute_amplifiers.amplifiers"),
                     { newValue -> entityAttributeAmplifier.amplifiers = newValue },
                     { amplifierElement: AttributeAmplifier?, _ ->
-                        val defaultAttribute = ResourceKey.create(Registries.ATTRIBUTE, ResourceLocation(""))
                         val amplifier = amplifierElement ?: AttributeAmplifier(ResourceKey.create(Registries.ATTRIBUTE, ResourceLocation("")), 1.5)
                         val attribute = amplifier.attribute
                         val numAmplifier = amplifier.amplifier
@@ -384,7 +384,7 @@ private fun entityHurtEffects(
         tooltip("entity_hurt_effects"),
         { newValue -> config.entityHurtEffects = newValue},
         { element: EntityHurtEffects?, _ ->
-            val entityHurtEffect = element ?: EntityHurtEffects(ResourceLocation(""), "", listOf(MobEffectHolder(ResourceKey.create(Registries.MOB_EFFECT, ResourceLocation("minecraft:speed")), 0, 0, true, true, true)))
+            val entityHurtEffect = element ?: EntityHurtEffects(ResourceLocation(""), "", mutableListOf(MobEffectHolder(ResourceKey.create(Registries.MOB_EFFECT, ResourceLocation("minecraft:speed")), 0, 0, true, true, true)))
             multiElementEntry(
                 text("entity_hurt_effects.dropdown"),
                 entityHurtEffect,
@@ -405,7 +405,7 @@ private fun entityHurtEffects(
                     entryBuilder,
                     text("entity_hurt_effects.hurt_effects"),
                     entityHurtEffect::effects,
-                    { listOf(MobEffectHolder(ResourceKey.create(Registries.MOB_EFFECT, ResourceLocation("speed")), 5, 10, true, true, true)) },
+                    { mutableListOf(MobEffectHolder(ResourceKey.create(Registries.MOB_EFFECT, ResourceLocation("speed")), 5, 10, true, true, true)) },
                     true,
                     tooltip("entity_hurt_effects.hurt_effects"),
                     { newValue -> entityHurtEffect.effects = newValue },
@@ -421,31 +421,31 @@ private fun entityHurtEffects(
                                 tooltip("entity_hurt_effects.effect")
                             ).build(entryBuilder),
 
-                            EntryBuilder(text("entity_hurt_effects.duration"), effect.duration ?: 0,
+                            EntryBuilder(text("entity_hurt_effects.duration"), effect.duration,
                                 0,
                                 { newValue -> effect.duration = newValue },
                                 tooltip("entity_hurt_effects.duration")
                             ).build(entryBuilder),
 
-                            EntryBuilder(text("entity_hurt_effects.amplifier"), effect.amplifier ?: 0,
+                            EntryBuilder(text("entity_hurt_effects.amplifier"), effect.amplifier,
                                 0,
                                 { newValue -> effect.amplifier = newValue },
                                 tooltip("entity_hurt_effects.amplifier")
                             ).build(entryBuilder),
 
-                            EntryBuilder(text("entity_hurt_effects.ambient"), effect.ambient ?: false,
+                            EntryBuilder(text("entity_hurt_effects.ambient"), effect.ambient,
                                 true,
                                 { newValue -> effect.ambient = newValue },
                                 tooltip("entity_hurt_effects.ambient")
                             ).build(entryBuilder),
 
-                            EntryBuilder(text("entity_hurt_effects.visible"), effect.visible ?: false,
+                            EntryBuilder(text("entity_hurt_effects.visible"), effect.visible,
                                 true,
                                 { newValue -> effect.visible = newValue },
                                 tooltip("entity_hurt_effects.visible")
                             ).build(entryBuilder),
 
-                            EntryBuilder(text("entity_hurt_effects.show_icon"), effect.showIcon ?: false,
+                            EntryBuilder(text("entity_hurt_effects.show_icon"), effect.showIcon,
                                 true,
                                 { newValue -> effect.showIcon = newValue },
                                 tooltip("entity_hurt_effects.show_icon")

--- a/src/main/java/net/frozenblock/configurableeverything/config/gui/SplashTextConfigGui.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/config/gui/SplashTextConfigGui.kt
@@ -27,7 +27,7 @@ object SplashTextConfigGui {
 
         val added = EntryBuilder(text("added_splashes"), StringList(config.addedSplashes),
             StringList(defaultConfig.addedSplashes),
-            { newValue -> config.addedSplashes = newValue.list },
+            { newValue -> config.addedSplashes = newValue.list.toMutableList() },
             tooltip("added_splashes"),
             true,
             requirement = mainToggleReq,
@@ -37,7 +37,7 @@ object SplashTextConfigGui {
 
         val removed = EntryBuilder(text("removed_splashes"), StringList(config.removedSplashes),
             StringList(defaultConfig.removedSplashes),
-            { newValue -> config.removedSplashes = newValue.list },
+            { newValue -> config.removedSplashes = newValue.list.toMutableList() },
             tooltip("removed_splashes"),
             true,
             requirement = mainToggleReq,

--- a/src/main/java/net/frozenblock/configurableeverything/datafixer/util/DataFixEntry.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/datafixer/util/DataFixEntry.kt
@@ -2,17 +2,18 @@ package net.frozenblock.configurableeverything.datafixer.util
 
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 
 data class DataFixEntry(
     @JvmField var type: String,
-    @JvmField var fixers: List<Fixer>
+    @JvmField var fixers: MutableList<Fixer>
 ) {
     companion object {
         @JvmField
         val CODEC: Codec<DataFixEntry> = RecordCodecBuilder.create { instance ->
             instance.group(
                 Codec.STRING.fieldOf("type").forGetter(DataFixEntry::type),
-                Codec.list(Fixer.CODEC).fieldOf("fixers").forGetter(DataFixEntry::fixers)
+                Fixer.CODEC.mutListOf().fieldOf("fixers").forGetter(DataFixEntry::fixers)
             ).apply(instance, ::DataFixEntry)
         }
     }

--- a/src/main/java/net/frozenblock/configurableeverything/datafixer/util/DataFixerUtil.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/datafixer/util/DataFixerUtil.kt
@@ -100,7 +100,7 @@ object DataFixerUtil {
             "entity" -> SimpleFixes.addEntityRenameFix(builder, fixName, oldId, newId, schema)
             "item" -> {
                 SimpleFixes.addItemRenameFix(builder, fixName, oldId, newId, schema)
-                REGISTRY_FIXERS.add(RegistryFixer(ResourceLocation("item"), listOf(Fixer(oldId, newId))))
+                REGISTRY_FIXERS.add(RegistryFixer(ResourceLocation("item"), mutableListOf(Fixer(oldId, newId))))
             }
 
             else -> logError("Invalid data fix type: " + entry.type)

--- a/src/main/java/net/frozenblock/configurableeverything/datafixer/util/RegistryFixer.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/datafixer/util/RegistryFixer.kt
@@ -11,14 +11,14 @@ import net.minecraft.resources.ResourceLocation
 
 data class RegistryFixer(
     @JvmField var registryKey: ResourceLocation,
-    @JvmField var fixers: List<Fixer>
+    @JvmField var fixers: MutableList<Fixer>
 ) {
     companion object {
         @JvmField
 		val CODEC: Codec<RegistryFixer> = RecordCodecBuilder.create { instance ->
             instance.group(
                 ResourceLocation.CODEC.fieldOf("registry_key").forGetter(RegistryFixer::registryKey),
-                Fixer.CODEC.listOf().fieldOf("fixers").forGetter(RegistryFixer::fixers)
+                Fixer.CODEC.mutListOf().fieldOf("fixers").forGetter(RegistryFixer::fixers)
             ).apply(instance, ::RegistryFixer)
         }
 

--- a/src/main/java/net/frozenblock/configurableeverything/datafixer/util/RegistryFixer.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/datafixer/util/RegistryFixer.kt
@@ -2,6 +2,7 @@ package net.frozenblock.configurableeverything.datafixer.util
 
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 import net.frozenblock.configurableeverything.config.DataFixerConfig
 import net.frozenblock.configurableeverything.datafixer.util.DataFixerUtil.REGISTRY_FIXERS
 import net.frozenblock.configurableeverything.util.UNSTABLE_LOGGING

--- a/src/main/java/net/frozenblock/configurableeverything/datafixer/util/SchemaEntry.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/datafixer/util/SchemaEntry.kt
@@ -2,17 +2,18 @@ package net.frozenblock.configurableeverything.datafixer.util
 
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 
 data class SchemaEntry(
     @JvmField var version: Int,
-    @JvmField var entries: List<DataFixEntry>
+    @JvmField var entries: MutableList<DataFixEntry>
 ) {
     companion object {
         @JvmField
         val CODEC: Codec<SchemaEntry> = RecordCodecBuilder.create { instance ->
             instance.group(
                 Codec.INT.fieldOf("version").forGetter(SchemaEntry::version),
-                Codec.list(DataFixEntry.CODEC).fieldOf("data_fixes").forGetter(SchemaEntry::entries)
+                DataFixEntry.CODEC.mutListOf().fieldOf("data_fixes").forGetter(SchemaEntry::entries)
             ).apply(instance, ::SchemaEntry)
         }
     }

--- a/src/main/java/net/frozenblock/configurableeverything/entity/util/EntityAttributeAmplifier.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/entity/util/EntityAttributeAmplifier.kt
@@ -2,6 +2,7 @@ package net.frozenblock.configurableeverything.entity.util
 
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceKey
 import net.minecraft.world.entity.EntityType

--- a/src/main/java/net/frozenblock/configurableeverything/entity/util/EntityAttributeAmplifier.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/entity/util/EntityAttributeAmplifier.kt
@@ -9,7 +9,7 @@ import net.minecraft.world.entity.EntityType
 data class EntityAttributeAmplifier(
 	@JvmField var entity: ResourceKey<EntityType<*>>,
 	@JvmField var entityName: String,
-	@JvmField var amplifiers: List<AttributeAmplifier>
+	@JvmField var amplifiers: MutableList<AttributeAmplifier>
 ) {
     companion object {
         @JvmField
@@ -17,7 +17,7 @@ data class EntityAttributeAmplifier(
             instance.group(
                 ResourceKey.codec(Registries.ENTITY_TYPE).fieldOf("entity").forGetter(EntityAttributeAmplifier::entity),
                 Codec.STRING.fieldOf("entityName").forGetter(EntityAttributeAmplifier::entityName),
-                AttributeAmplifier.CODEC.listOf().fieldOf("amplifiers").forGetter(EntityAttributeAmplifier::amplifiers)
+                AttributeAmplifier.CODEC.mutListOf().fieldOf("amplifiers").forGetter(EntityAttributeAmplifier::amplifiers)
             ).apply(instance, ::EntityAttributeAmplifier)
         }
     }

--- a/src/main/java/net/frozenblock/configurableeverything/entity/util/EntityHurtEffects.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/entity/util/EntityHurtEffects.kt
@@ -2,6 +2,7 @@ package net.frozenblock.configurableeverything.entity.util
 
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 import net.minecraft.resources.ResourceLocation
 
 data class EntityHurtEffects(

--- a/src/main/java/net/frozenblock/configurableeverything/entity/util/EntityHurtEffects.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/entity/util/EntityHurtEffects.kt
@@ -7,7 +7,7 @@ import net.minecraft.resources.ResourceLocation
 data class EntityHurtEffects(
     @JvmField var entity: ResourceLocation,
     @JvmField var entityName: String,
-    @JvmField var effects: List<MobEffectHolder>
+    @JvmField var effects: MutableList<MobEffectHolder>
 ) {
     companion object {
         @JvmField
@@ -15,7 +15,7 @@ data class EntityHurtEffects(
             instance.group(
                 ResourceLocation.CODEC.fieldOf("entity").forGetter(EntityHurtEffects::entity),
                 Codec.STRING.fieldOf("entityName").forGetter(EntityHurtEffects::entityName),
-                MobEffectHolder.CODEC.listOf().fieldOf("effects").forGetter(EntityHurtEffects::effects)
+                MobEffectHolder.CODEC.mutListOf().fieldOf("effects").forGetter(EntityHurtEffects::effects)
             ).apply(instance, ::EntityHurtEffects)
         }
     }

--- a/src/main/java/net/frozenblock/configurableeverything/gravity/util/DimensionGravityBelt.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/gravity/util/DimensionGravityBelt.kt
@@ -2,6 +2,7 @@ package net.frozenblock.configurableeverything.gravity.util
 
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 import net.frozenblock.lib.gravity.api.GravityBelt
 import net.frozenblock.lib.gravity.api.functions.AbsoluteGravityFunction
 import net.minecraft.core.registries.Registries

--- a/src/main/java/net/frozenblock/configurableeverything/gravity/util/DimensionGravityBelt.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/gravity/util/DimensionGravityBelt.kt
@@ -13,14 +13,14 @@ data class DimensionGravityBelt(
     var dimension: ResourceKey<Level>,
 
     @JvmField
-    var gravityBelts: List<GravityBelt<AbsoluteGravityFunction>>
+    var gravityBelts: MutableList<GravityBelt<AbsoluteGravityFunction>>
 ) {
     companion object {
         @JvmField
         val CODEC: Codec<DimensionGravityBelt> = RecordCodecBuilder.create { instance ->
             instance.group(
                 ResourceKey.codec(Registries.DIMENSION).fieldOf("dimension").forGetter(DimensionGravityBelt::dimension),
-                AbsoluteGravityFunction.BELT_CODEC.listOf().fieldOf("gravityBelts").forGetter(DimensionGravityBelt::gravityBelts)
+                AbsoluteGravityFunction.BELT_CODEC.mutListOf().fieldOf("gravityBelts").forGetter(DimensionGravityBelt::gravityBelts)
             ).apply(instance, ::DimensionGravityBelt)
         }
     }

--- a/src/main/java/net/frozenblock/configurableeverything/loot/util/LootModification.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/loot/util/LootModification.kt
@@ -2,6 +2,7 @@ package net.frozenblock.configurableeverything.loot.util
 
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.level.storage.loot.LootPool
 import java.util.*

--- a/src/main/java/net/frozenblock/configurableeverything/loot/util/LootModification.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/loot/util/LootModification.kt
@@ -7,7 +7,7 @@ import net.minecraft.world.level.storage.loot.LootPool
 import java.util.*
 import kotlin.jvm.optionals.getOrNull
 
-data class LootModification(var id: ResourceLocation, var pool: LootPool? = null, var removals: List<ResourceLocation?>? = listOf()) {
+data class LootModification(var id: ResourceLocation, var pool: LootPool? = null, var removals: MutableList<ResourceLocation?>? = mutableListOf()) {
 
     constructor(id: ResourceLocation, pool: Optional<LootPool>?, removals: Optional<List<ResourceLocation?>>?) : this(id, pool?.getOrNull(), removals?.getOrNull())
 
@@ -17,7 +17,7 @@ data class LootModification(var id: ResourceLocation, var pool: LootPool? = null
             instance.group(
                 ResourceLocation.CODEC.fieldOf("id").forGetter(LootModification::id),
                 LootPool.CODEC.optionalFieldOf("addition_pool").forGetter { Optional.ofNullable(it.pool) },
-                ResourceLocation.CODEC.listOf().optionalFieldOf("removals").forGetter { Optional.ofNullable(it.removals) }
+                ResourceLocation.CODEC.mutListOf().optionalFieldOf("removals").forGetter { Optional.ofNullable(it.removals) }
             ).apply(instance, ::LootModification)
         }
     }

--- a/src/main/java/net/frozenblock/configurableeverything/loot/util/LootModification.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/loot/util/LootModification.kt
@@ -10,7 +10,7 @@ import kotlin.jvm.optionals.getOrNull
 
 data class LootModification(var id: ResourceLocation, var pool: LootPool? = null, var removals: MutableList<ResourceLocation?>? = mutableListOf()) {
 
-    constructor(id: ResourceLocation, pool: Optional<LootPool>?, removals: Optional<List<ResourceLocation?>>?) : this(id, pool?.getOrNull(), removals?.getOrNull())
+    constructor(id: ResourceLocation, pool: Optional<LootPool>?, removals: Optional<MutableList<ResourceLocation?>>?) : this(id, pool?.getOrNull(), removals?.getOrNull())
 
     companion object {
         @JvmField

--- a/src/main/java/net/frozenblock/configurableeverything/scripting/util/ConfigData.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/scripting/util/ConfigData.kt
@@ -9,7 +9,7 @@ import net.frozenblock.lib.config.api.instance.ConfigModification
 import net.frozenblock.lib.config.api.registry.ConfigRegistry
 import java.util.function.Consumer
 
-sealed class StableConfigData<T : Any>(override val config: Config<T>): ConfigData<T>(config) {
+sealed class StableConfigData<T : Any, C>(override val config: Config<T>): ConfigData<T, C>(config) where C : ConfigWrapper<T> {
     override fun get(): T = super.get()!!
 }
 
@@ -18,37 +18,97 @@ sealed class StableConfigData<T : Any>(override val config: Config<T>): ConfigDa
  * @since 1.1
  */
 @Suppress("unused", "ClassName")
-sealed class ConfigData<T : Any>(open val config: Config<T>?) {
-    data object MAIN : StableConfigData<MainConfig>(MainConfig)
-    data object BIOME : StableConfigData<BiomeConfig>(BiomeConfig)
-    data object BIOME_PLACEMENT : StableConfigData<BiomePlacementConfig>(BiomePlacementConfig)
-    data object BLOCK : StableConfigData<BlockConfig>(BlockConfig)
-    data object DATAFIXER : StableConfigData<DataFixerConfig>(DataFixerConfig)
-    data object ENTITY : StableConfigData<EntityConfig>(EntityConfig)
-    data object FLUID : StableConfigData<FluidConfig>(FluidConfig)
-    data object GRAVITY : StableConfigData<GravityConfig>(GravityConfig)
-    data object ITEM : StableConfigData<ItemConfig>(ItemConfig)
-    data object LOOT : StableConfigData<LootConfig>(LootConfig)
-    data object REGISTRY : StableConfigData<RegistryConfig>(RegistryConfig)
-    data object SCREEN_SHAKE : StableConfigData<ScreenShakeConfig>(ScreenShakeConfig)
-    data object SCULK_SPREADING : StableConfigData<SculkSpreadingConfig>(SculkSpreadingConfig)
+sealed class ConfigData<T : Any, C>(open val config: Config<T>?) where C : ConfigWrapper<T> {
+    data object MAIN : StableConfigData<MainConfig, MainWrapper>(MainConfig) {
+        override fun modify(modification: (MainWrapper) -> Unit) {
+            ConfigRegistry.register(MainConfig, ConfigModification { modification(MainWrapper(it)) })
+        }
+    }
+    data object BIOME : StableConfigData<BiomeConfig, BiomeWrapper>(BiomeConfig) {
+        override fun modify(modification: (BiomeWrapper) -> Unit) {
+            ConfigRegistry.register(BiomeConfig, ConfigModification { modification(BiomeWrapper(it)) })
+        }
+    }
+    data object BIOME_PLACEMENT : StableConfigData<BiomePlacementConfig, BiomePlacementWrapper>(BiomePlacementConfig) {
+        override fun modify(modification: (BiomePlacementWrapper) -> Unit) {
+            ConfigRegistry.register(BiomePlacementConfig, ConfigModification { modification(BiomePlacementWrapper(it)) })
+        }
+    }
+    data object BLOCK : StableConfigData<BlockConfig, BlockWrapper>(BlockConfig) {
+        override fun modify(modification: (BlockWrapper) -> Unit) {
+            ConfigRegistry.register(BlockConfig, ConfigModification { modification(BlockWrapper(it)) })
+        }
+    }
+    data object DATAFIXER : StableConfigData<DataFixerConfig, DataFixerWrapper>(DataFixerConfig) {
+        override fun modify(modification: (DataFixerWrapper) -> Unit) {
+            ConfigRegistry.register(DataFixerConfig, ConfigModification { modification(DataFixerWrapper(it)) })
+        }
+    }
+    data object ENTITY : StableConfigData<EntityConfig, EntityWrapper>(EntityConfig) {
+        override fun modify(modification: (EntityWrapper) -> Unit) {
+            ConfigRegistry.register(EntityConfig, ConfigModification { modification(EntityWrapper(it)) })
+        }
+    }
+    data object FLUID : StableConfigData<FluidConfig, FluidWrapper>(FluidConfig) {
+        override fun modify(modification: (FluidWrapper) -> Unit) {
+            ConfigRegistry.register(FluidConfig, ConfigModification { modification(FluidWrapper(it)) })
+        }
+    }
+    data object GRAVITY : StableConfigData<GravityConfig, GravityWrapper>(GravityConfig) {
+        override fun modify(modification: (GravityWrapper) -> Unit) {
+            ConfigRegistry.register(GravityConfig, ConfigModification { modification(GravityWrapper(it)) })
+        }
+    }
+    data object ITEM : StableConfigData<ItemConfig, ItemWrapper>(ItemConfig) {
+        override fun modify(modification: (ItemWrapper) -> Unit) {
+            ConfigRegistry.register(ItemConfig, ConfigModification { modification(ItemWrapper(it)) })
+        }
+    }
+    data object LOOT : StableConfigData<LootConfig, LootWrapper>(LootConfig) {
+        override fun modify(modification: (LootWrapper) -> Unit) {
+            ConfigRegistry.register(LootConfig, ConfigModification { modification(LootWrapper(it)) })
+        }
+    }
+    data object REGISTRY : StableConfigData<RegistryConfig, RegistryWrapper>(RegistryConfig) {
+        override fun modify(modification: (RegistryWrapper) -> Unit) {
+            ConfigRegistry.register(RegistryConfig, ConfigModification { modification(RegistryWrapper(it)) })
+        }
+    }
+    data object SCREEN_SHAKE : StableConfigData<ScreenShakeConfig, ScreenShakeWrapper>(ScreenShakeConfig) {
+        override fun modify(modification: (ScreenShakeWrapper) -> Unit) {
+            ConfigRegistry.register(ScreenShakeConfig, ConfigModification { modification(ScreenShakeWrapper(it)) })
+        }
+    }
+    data object SCULK_SPREADING : StableConfigData<SculkSpreadingConfig, SculkSpreadingWrapper>(SculkSpreadingConfig) {
+        override fun modify(modification: (SculkSpreadingWrapper) -> Unit) {
+            ConfigRegistry.register(SculkSpreadingConfig, ConfigModification { modification(SculkSpreadingWrapper(it)) })
+        }
+    }
     @Environment(EnvType.CLIENT)
-    data object SPLASH_TEXT : StableConfigData<SplashTextConfig>(SplashTextConfig)
-    data object STRUCTURE : StableConfigData<StructureConfig>(StructureConfig)
-    data object SURFACE_RULE : StableConfigData<SurfaceRuleConfig>(SurfaceRuleConfig)
-    data object TAG : ConfigData<TagConfig>(ifExperimental { TagConfig })
-    data object WORLD : StableConfigData<WorldConfig>(WorldConfig)
+    data object SPLASH_TEXT : StableConfigData<SplashTextConfig, SplashTextWrapper>(SplashTextConfig) {
+        override fun modify(modification: (SplashTextWrapper) -> Unit) {
+            ConfigRegistry.register(SplashTextConfig, ConfigModification { modification(SplashTextWrapper(it)) })
+        }
+    }
+    data object STRUCTURE : StableConfigData<StructureConfig, StructureWrapper>(StructureConfig) {
+        override fun modify(modification: (StructureWrapper) -> Unit) {
+            ConfigRegistry.register(StructureConfig, ConfigModification { modification(StructureWrapper(it)) })
+        }
+    }
+    data object SURFACE_RULE : StableConfigData<SurfaceRuleConfig, SurfaceRuleWrapper>(SurfaceRuleConfig) {
+        override fun modify(modification: (SurfaceRuleWrapper) -> Unit) {
+            ConfigRegistry.register(SurfaceRuleConfig, ConfigModification { modification(SurfaceRuleWrapper(it)) })
+        }
+    }
+    data object WORLD : StableConfigData<WorldConfig, WorldWrapper>(WorldConfig) {
+        override fun modify(modification: (WorldWrapper) -> Unit) {
+            ConfigRegistry.register(WorldConfig, ConfigModification { modification(WorldWrapper(it)) })
+        }
+    }
+
+    abstract fun modify(modification: (C) -> Unit)
 
     open fun get(): T? = config?.config()
-
-    fun modify(modification: ConfigModification<T>)
-        = config?.also { ConfigRegistry.register(it, modification) }
-
-    @Suppress("NOTHING_TO_INLINE")
-    inline fun modify(modification: Consumer<T>)
-        = modify(ConfigModification(modification))
-
-    inline fun modify(crossinline modification: (T) -> Unit)
-        = modify(Consumer { config -> modification(config) })
 }
 
+open class ConfigWrapper<T : Any>(protected val config: T)

--- a/src/main/java/net/frozenblock/configurableeverything/scripting/util/ConfigData.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/scripting/util/ConfigData.kt
@@ -26,7 +26,6 @@ sealed class ConfigData<T : Any>(open val config: Config<T>?) {
     data object DATAFIXER : StableConfigData<DataFixerConfig>(DataFixerConfig)
     data object ENTITY : StableConfigData<EntityConfig>(EntityConfig)
     data object FLUID : StableConfigData<FluidConfig>(FluidConfig)
-    data object GAME : StableConfigData<GameConfig>(GameConfig)
     data object GRAVITY : StableConfigData<GravityConfig>(GravityConfig)
     data object ITEM : StableConfigData<ItemConfig>(ItemConfig)
     data object LOOT : StableConfigData<LootConfig>(LootConfig)

--- a/src/main/java/net/frozenblock/configurableeverything/scripting/util/wrappers.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/scripting/util/wrappers.kt
@@ -51,38 +51,38 @@ class MainWrapper internal constructor(config: MainConfig) : ConfigWrapper<MainC
 
 class BiomeWrapper internal constructor(config: BiomeConfig) : ConfigWrapper<BiomeConfig>(config) {
 
-    var addedFeatures: List<BiomePlacedFeatureList> by config.addedFeatures
-    var removedFeatures: List<BiomePlacedFeatureList> by config.removedFeatures
-    var replacedFeatures: List<BiomePlacedFeatureReplacementList> by config.replacedFeatures
-    var musicReplacements: List<BiomeMusic> by config.musicReplacements
+    var addedFeatures: MutableList<BiomePlacedFeatureList> by config.addedFeatures
+    var removedFeatures: MutableList<BiomePlacedFeatureList> by config.removedFeatures
+    var replacedFeatures: MutableList<BiomePlacedFeatureReplacementList> by config.replacedFeatures
+    var musicReplacements: MutableList<BiomeMusic> by config.musicReplacements
 }
 
 class BiomePlacementWrapper internal constructor(config: BiomePlacementConfig) : ConfigWrapper<BiomePlacementConfig>(config) {
 
-    var addedBiomes: List<DimensionBiomeList> by config.addedBiomes
-    var removedBiomes: List<DimensionBiomeKeyList> by config.removedBiomes
+    var addedBiomes: MutableList<DimensionBiomeList> by config.addedBiomes
+    var removedBiomes: MutableList<DimensionBiomeKeyList> by config.removedBiomes
 }
 
 class BlockWrapper internal constructor(config: BlockConfig) : ConfigWrapper<BlockConfig>(config) {
 
-    var soundGroupOverwrites: List<MutableBlockSoundGroupOverwrite> by config.soundGroupOverwrites
+    var soundGroupOverwrites: MutableList<MutableBlockSoundGroupOverwrite> by config.soundGroupOverwrites
 }
 
 class DataFixerWrapper internal constructor(config: DataFixerConfig) : ConfigWrapper<DataFixerConfig>(config) {
 
     var overrideRealEntries: Boolean by config::overrideRealEntries
     var dataVersion: Int by config::dataVersion
-    var schemas: List<SchemaEntry> by config.schemas
-    var registryFixers: List<RegistryFixer> by config.registryFixers
+    var registryFixers: MutableList<RegistryFixer> by config.registryFixers
+    var schemas: MutableList<SchemaEntry> by config.schemas
 }
 
 class EntityWrapper internal constructor(config: EntityConfig) : ConfigWrapper<EntityConfig>(config) {
 
-    var entityAttributeAmplifiers: List<EntityAttributeAmplifier> by config.entityAttributeAmplifiers
-    var experienceOverrides: List<ExperienceOverride> by config.experienceOverrides
-    var entityFlyBySounds: List<EntityFlyBySound> by config.entityFlyBySounds
-    var entityHurtEffects: List<EntityHurtEffects> by config.entityHurtEffects
-    var entitySpottingIcon: List<EntitySpottingIcon> by config.entitySpottingIcons
+    var entityAttributeAmplifiers: MutableList<EntityAttributeAmplifier> by config.entityAttributeAmplifiers
+    var experienceOverrides: MutableList<ExperienceOverride> by config.experienceOverrides
+    var entityFlyBySounds: MutableList<EntityFlyBySound> by config.entityFlyBySounds
+    var entityHurtEffects: MutableList<EntityHurtEffects> by config.entityHurtEffects
+    var entitySpottingIcon: MutableList<EntitySpottingIcon> by config.entitySpottingIcons
     var flamingArrowsLightFire: Boolean by config::flamingArrowsLightFire
     var player: EntityConfig.PlayerConfig by config::player
     var zombie: EntityConfig.ZombieConfig by config::zombie
@@ -91,59 +91,59 @@ class EntityWrapper internal constructor(config: EntityConfig) : ConfigWrapper<E
 
 class FluidWrapper internal constructor(config: FluidConfig) : ConfigWrapper<FluidConfig>(config) {
 
-    var flowSpeeds: List<FluidFlowSpeed> by config.flowSpeeds
+    var flowSpeeds: MutableList<FluidFlowSpeed> by config.flowSpeeds
 }
 
 class GravityWrapper internal constructor(config: GravityConfig) : ConfigWrapper<GravityConfig>(config) {
 
-    var gravityBelts: List<DimensionGravityBelt> by config.gravityBelts
+    var gravityBelts: MutableList<DimensionGravityBelt> by config.gravityBelts
 }
 
 class ItemWrapper internal constructor(config: ItemConfig) : ConfigWrapper<ItemConfig>(config) {
 
-    var reachOverrideds: List<ItemReachOverride> by config.reachOverrides
+    var reachOverrideds: MutableList<ItemReachOverride> by config.reachOverrides
 }
 
 class LootWrapper internal constructor(config: LootConfig) : ConfigWrapper<LootConfig>(config) {
 
-    var lootModifications: List<LootModification> by config.lootModifications
+    var lootModifications: MutableList<LootModification> by config.lootModifications
 }
 
 class RegistryWrapper internal constructor(config: RegistryConfig) : ConfigWrapper<RegistryConfig>(config) {
 
-    var biomeAdditions: List<BiomeAddition> by config.biomeAdditions
-    var placedFeatureAdditions: List<PlacedFeatureAddition> by config.placedFeatureAdditions
+    var biomeAdditions: MutableList<BiomeAddition> by config.biomeAdditions
+    var placedFeatureAdditions: MutableList<PlacedFeatureAddition> by config.placedFeatureAdditions
 }
 
 class ScreenShakeWrapper internal constructor(config: ScreenShakeConfig) : ConfigWrapper<ScreenShakeConfig>(config) {
 
-    var soundScreenShakes: List<SoundScreenShake> by config.soundScreenShakes
+    var soundScreenShakes: MutableList<SoundScreenShake> by config.soundScreenShakes
     var dragonRespawnScreenShake: Boolean by config::dragonRespawnScreenShake
     var explosionScreenShake: Boolean by config::explosionScreenShake
 }
 
 class SculkSpreadingWrapper internal constructor(config: SculkSpreadingConfig) : ConfigWrapper<SculkSpreadingConfig>(config) {
 
-    var growths: List<SculkGrowth> by config.growths
+    var growths: MutableList<SculkGrowth> by config.growths
 }
 
 class SplashTextWrapper internal constructor(config: SplashTextConfig) : ConfigWrapper<SplashTextConfig>(config) {
 
-    var addedSplashes: List<String> by config::addedSplashes
-    var removedSplashes: List<String> by config::removedSplashes
+    var addedSplashes: MutableList<String> by config::addedSplashes
+    var removedSplashes: MutableList<String> by config::removedSplashes
     var splashColor: Int by config::splashColor
     var removeVanilla: Boolean by config::removeVanilla
 }
 
 class StructureWrapper internal constructor(config: StructureConfig) : ConfigWrapper<StructureConfig>(config) {
 
-    var removedStructures: List<ResourceLocation> by config.removedStructures
-    var removedStructureSets: List<ResourceLocation> by config.removedStructureSets
+    var removedStructures: MutableList<ResourceLocation> by config.removedStructures
+    var removedStructureSets: MutableList<ResourceLocation> by config.removedStructureSets
 }
 
 class SurfaceRuleWrapper internal constructor(config: SurfaceRuleConfig) : ConfigWrapper<SurfaceRuleConfig>(config) {
 
-    var addedSurfaceRules: List<FrozenDimensionBoundRuleSource> by config.addedSurfaceRules
+    var addedSurfaceRules: MutableList<FrozenDimensionBoundRuleSource> by config.addedSurfaceRules
 }
 
 class WorldWrapper internal constructor(config: WorldConfig) : ConfigWrapper<WorldConfig>(config) {

--- a/src/main/java/net/frozenblock/configurableeverything/scripting/util/wrappers.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/scripting/util/wrappers.kt
@@ -1,0 +1,156 @@
+package net.frozenblock.configurableeverything.scripting.util
+
+import net.frozenblock.configurableeverything.biome.util.BiomeMusic
+import net.frozenblock.configurableeverything.biome.util.BiomePlacedFeatureList
+import net.frozenblock.configurableeverything.biome.util.BiomePlacedFeatureReplacementList
+import net.frozenblock.configurableeverything.biome_placement.util.DimensionBiomeKeyList
+import net.frozenblock.configurableeverything.biome_placement.util.DimensionBiomeList
+import net.frozenblock.configurableeverything.block.util.MutableBlockSoundGroupOverwrite
+import net.frozenblock.configurableeverything.config.*
+import net.frozenblock.configurableeverything.datafixer.util.RegistryFixer
+import net.frozenblock.configurableeverything.datafixer.util.SchemaEntry
+import net.frozenblock.configurableeverything.entity.util.*
+import net.frozenblock.configurableeverything.fluid.util.FluidFlowSpeed
+import net.frozenblock.configurableeverything.gravity.util.DimensionGravityBelt
+import net.frozenblock.configurableeverything.item.util.ItemReachOverride
+import net.frozenblock.configurableeverything.loot.util.LootModification
+import net.frozenblock.configurableeverything.registry.util.BiomeAddition
+import net.frozenblock.configurableeverything.registry.util.PlacedFeatureAddition
+import net.frozenblock.configurableeverything.screenshake.util.SoundScreenShake
+import net.frozenblock.configurableeverything.sculk_spreading.util.SculkGrowth
+import net.frozenblock.configurableeverything.util.getValue
+import net.frozenblock.configurableeverything.util.setValue
+import net.frozenblock.lib.config.api.entry.TypedEntry
+import net.frozenblock.lib.worldgen.surface.api.FrozenDimensionBoundRuleSource
+import net.minecraft.resources.ResourceLocation
+
+class MainWrapper internal constructor(config: MainConfig) : ConfigWrapper<MainConfig>(config) {
+
+    var biome: Boolean by config::biome
+    var biome_placement: Boolean by config::biome_placement
+    var block: Boolean by config::block
+    var datafixer: Boolean by config::datafixer
+    var entity: Boolean by config::entity
+    var fluid: Boolean by config::fluid
+    var game: Boolean by config::game
+    var gravity: Boolean by config::gravity
+    var item: Boolean by config::item
+    var loot: Boolean by config::loot
+    var music: Boolean by config::music
+    var registry: Boolean by config::registry
+    var screen_shake: Boolean by config::screen_shake
+    var scripting: Boolean by config::scripting
+    var sculk_spreading: Boolean by config::sculk_spreading
+    var splash_text: Boolean by config::splash_text
+    var structure: Boolean by config::structure
+    var surface_rule: Boolean by config::surface_rule
+    var tag: Boolean by config::tag
+    var world: Boolean by config::world
+    var datapack: MainConfig.DatapackConfig by config::datapack
+}
+
+class BiomeWrapper internal constructor(config: BiomeConfig) : ConfigWrapper<BiomeConfig>(config) {
+
+    var addedFeatures: List<BiomePlacedFeatureList> by config.addedFeatures
+    var removedFeatures: List<BiomePlacedFeatureList> by config.removedFeatures
+    var replacedFeatures: List<BiomePlacedFeatureReplacementList> by config.replacedFeatures
+    var musicReplacements: List<BiomeMusic> by config.musicReplacements
+}
+
+class BiomePlacementWrapper internal constructor(config: BiomePlacementConfig) : ConfigWrapper<BiomePlacementConfig>(config) {
+
+    var addedBiomes: List<DimensionBiomeList> by config.addedBiomes
+    var removedBiomes: List<DimensionBiomeKeyList> by config.removedBiomes
+}
+
+class BlockWrapper internal constructor(config: BlockConfig) : ConfigWrapper<BlockConfig>(config) {
+
+    var soundGroupOverwrites: List<MutableBlockSoundGroupOverwrite> by config.soundGroupOverwrites
+}
+
+class DataFixerWrapper internal constructor(config: DataFixerConfig) : ConfigWrapper<DataFixerConfig>(config) {
+
+    var overrideRealEntries: Boolean by config::overrideRealEntries
+    var dataVersion: Int by config::dataVersion
+    var schemas: List<SchemaEntry> by config.schemas
+    var registryFixers: List<RegistryFixer> by config.registryFixers
+}
+
+class EntityWrapper internal constructor(config: EntityConfig) : ConfigWrapper<EntityConfig>(config) {
+
+    var entityAttributeAmplifiers: List<EntityAttributeAmplifier> by config.entityAttributeAmplifiers
+    var experienceOverrides: List<ExperienceOverride> by config.experienceOverrides
+    var entityFlyBySounds: List<EntityFlyBySound> by config.entityFlyBySounds
+    var entityHurtEffects: List<EntityHurtEffects> by config.entityHurtEffects
+    var entitySpottingIcon: List<EntitySpottingIcon> by config.entitySpottingIcons
+    var flamingArrowsLightFire: Boolean by config::flamingArrowsLightFire
+    var player: EntityConfig.PlayerConfig by config::player
+    var zombie: EntityConfig.ZombieConfig by config::zombie
+    var skeleton: EntityConfig.SkeletonConfig by config::skeleton
+}
+
+class FluidWrapper internal constructor(config: FluidConfig) : ConfigWrapper<FluidConfig>(config) {
+
+    var flowSpeeds: List<FluidFlowSpeed> by config.flowSpeeds
+}
+
+class GravityWrapper internal constructor(config: GravityConfig) : ConfigWrapper<GravityConfig>(config) {
+
+    var gravityBelts: List<DimensionGravityBelt> by config.gravityBelts
+}
+
+class ItemWrapper internal constructor(config: ItemConfig) : ConfigWrapper<ItemConfig>(config) {
+
+    var reachOverrideds: List<ItemReachOverride> by config.reachOverrides
+}
+
+class LootWrapper internal constructor(config: LootConfig) : ConfigWrapper<LootConfig>(config) {
+
+    var lootModifications: List<LootModification> by config.lootModifications
+}
+
+class RegistryWrapper internal constructor(config: RegistryConfig) : ConfigWrapper<RegistryConfig>(config) {
+
+    var biomeAdditions: List<BiomeAddition> by config.biomeAdditions
+    var placedFeatureAdditions: List<PlacedFeatureAddition> by config.placedFeatureAdditions
+}
+
+class ScreenShakeWrapper internal constructor(config: ScreenShakeConfig) : ConfigWrapper<ScreenShakeConfig>(config) {
+
+    var soundScreenShakes: List<SoundScreenShake> by config.soundScreenShakes
+    var dragonRespawnScreenShake: Boolean by config::dragonRespawnScreenShake
+    var explosionScreenShake: Boolean by config::explosionScreenShake
+}
+
+class SculkSpreadingWrapper internal constructor(config: SculkSpreadingConfig) : ConfigWrapper<SculkSpreadingConfig>(config) {
+
+    var growths: List<SculkGrowth> by config.growths
+}
+
+class SplashTextWrapper internal constructor(config: SplashTextConfig) : ConfigWrapper<SplashTextConfig>(config) {
+
+    var addedSplashes: List<String> by config::addedSplashes
+    var removedSplashes: List<String> by config::removedSplashes
+    var splashColor: Int by config::splashColor
+    var removeVanilla: Boolean by config::removeVanilla
+}
+
+class StructureWrapper internal constructor(config: StructureConfig) : ConfigWrapper<StructureConfig>(config) {
+
+    var removedStructures: List<ResourceLocation> by config.removedStructures
+    var removedStructureSets: List<ResourceLocation> by config.removedStructureSets
+}
+
+class SurfaceRuleWrapper internal constructor(config: SurfaceRuleConfig) : ConfigWrapper<SurfaceRuleConfig>(config) {
+
+    var addedSurfaceRules: List<FrozenDimensionBoundRuleSource> by config.addedSurfaceRules
+}
+
+class WorldWrapper internal constructor(config: WorldConfig) : ConfigWrapper<WorldConfig>(config) {
+
+    var dayTimeSpeedAmplifier: Long by config::dayTimeSpeedAmplifier
+    var fixSunMoonRotating: Boolean by config::fixSunMoonRotating
+    var sunSize: Int by config::sunSize
+    var moonSize: Int by config::moonSize
+    var disableExperimentalWarning: Boolean by config::disableExperimentalWarning
+}

--- a/src/main/java/net/frozenblock/configurableeverything/tag/util/RegistryTagModification.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/tag/util/RegistryTagModification.kt
@@ -5,14 +5,14 @@ import com.mojang.serialization.codecs.RecordCodecBuilder
 
 data class RegistryTagModification(
     @JvmField var registry: String,
-    @JvmField var modifications: List<TagModification>
+    @JvmField var modifications: MutableList<TagModification>
 ) {
     companion object {
         @JvmField
         val CODEC: Codec<RegistryTagModification> = RecordCodecBuilder.create { instance ->
             instance.group(
                 Codec.STRING.fieldOf("registry").forGetter(RegistryTagModification::registry),
-                TagModification.CODEC.listOf().fieldOf("modifications").forGetter(RegistryTagModification::modifications),
+                TagModification.CODEC.mutListOf().fieldOf("modifications").forGetter(RegistryTagModification::modifications),
             ).apply(instance, ::RegistryTagModification)
         }
     }

--- a/src/main/java/net/frozenblock/configurableeverything/tag/util/RegistryTagModification.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/tag/util/RegistryTagModification.kt
@@ -2,6 +2,7 @@ package net.frozenblock.configurableeverything.tag.util
 
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 
 data class RegistryTagModification(
     @JvmField var registry: String,

--- a/src/main/java/net/frozenblock/configurableeverything/tag/util/TagModification.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/tag/util/TagModification.kt
@@ -2,6 +2,7 @@ package net.frozenblock.configurableeverything.tag.util
 
 import com.mojang.serialization.Codec
 import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.frozenblock.configurableeverything.util.mutListOf
 
 data class TagModification(
     @JvmField var tag: String,

--- a/src/main/java/net/frozenblock/configurableeverything/tag/util/TagModification.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/tag/util/TagModification.kt
@@ -5,16 +5,16 @@ import com.mojang.serialization.codecs.RecordCodecBuilder
 
 data class TagModification(
     @JvmField var tag: String,
-    @JvmField var additions: List<String>,
-    @JvmField var removals: List<String>
+    @JvmField var additions: MutableList<String>,
+    @JvmField var removals: MutableList<String>
 ) {
     companion object {
         @JvmField
         val CODEC: Codec<TagModification> = RecordCodecBuilder.create { instance ->
             instance.group(
                 Codec.STRING.fieldOf("tag").forGetter(TagModification::tag),
-                Codec.STRING.listOf().fieldOf("additions").forGetter(TagModification::additions),
-                Codec.STRING.listOf().fieldOf("removals").forGetter(TagModification::removals)
+                Codec.STRING.mutListOf().fieldOf("additions").forGetter(TagModification::additions),
+                Codec.STRING.mutListOf().fieldOf("removals").forGetter(TagModification::removals)
             ).apply(instance, ::TagModification)
         }
     }

--- a/src/main/java/net/frozenblock/configurableeverything/util/MutableListCodec.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/util/MutableListCodec.kt
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+package net.frozenblock.configurableeverything.util
+
+import com.mojang.datafixers.util.Pair
+import com.mojang.datafixers.util.Unit as DFUUnit
+import com.mojang.serialization.Codec
+import com.mojang.serialization.DataResult
+import com.mojang.serialization.DynamicOps
+import com.mojang.serialization.Lifecycle
+import com.mojang.serialization.ListBuilder
+import com.mojang.serialization.codecs.ListCodec;
+
+inline fun <T> Codec<T>.mutListOf(minSize: Int = 0, maxSize: Int = Int.MAX_VALUE): Codec<MutableList<T>>
+    = mutList(this, minSize, maxSize)
+
+inline fun <T> mutList(elementCodec: Codec<T>, minSize: Int = 0, maxSize: Int = Int.MAX_VALUE): Codec<MutableList<T>>
+    = ListCodec(elementCodec, minSize, maxSize)
+
+/**
+ * Based on Mojang's ListCodec
+ */
+data class MutableListCodec<E>(elementCodec: Codec<E>, minSize: Int = 0, maxSize: Int = Int.MAX_VALUE) : Codec<MutableList<E>> {
+    private val delegate = ListCodec(elementCodec, minSize, maxSize)
+
+    private fun <R> createTooShortError(size: Int): DataResult<R>
+        = DataResult.error { "List is too short: $size, expected range [${minSize}-${maxSize}]" }
+
+    private fun <R> createTooLongError(size: Int): DataResult<R>
+        = DataResult.error { "List is too long: $size, expected range [${minSize}-${maxSize}]" }
+
+    override fun <T> encode(input: MutableList<E>, ops: DynamicOps<T>, prefix: T): DataResult<T> {
+        return delegate.encode(input, ops, prefix)
+    }
+
+    override fun <T> decode(ops: DynamicOps<T>, input: T): DataResult<Pair<MutableList<E>, T>> {
+        return ops.getList(input).setLifecycle(Lifecycle.stable()).flatMap { stream ->
+            val decoder: DecoderState<T> = DecoderState(ops)
+            stream.accept(decoder::accept)
+            return@flatMap decoder.build()
+        }
+    }
+
+    override fun toString(): String
+        = "MutableListCodec[${elementCodec}]"
+
+    private inner class DecoderState<T>(private val ops: DynamicOps<T>) {
+        companion object {
+            private val INITIAL_RESULT: DataResult<DFUUnit> = DataResult.success(DFUUnit.INSTANCE, Lifecycle.stable())
+        }
+
+        private val elements: MutableList<E> = mutableListOf()
+        private val failed: Steam.Builder<T> = Stream.builder();
+        private var result: DataResult<DFUUnit> = INITIAL_RESULT
+        private var totalCount: Int
+
+        fun accept(value: T) {
+            totalCount++
+            if (elements.size() >= maxSize) {
+                failed.add(value)
+                return
+            }
+            val elementResult = elementCodec.decode(ops, value)
+            elementResult.error().ifPresent { error -> failed.add(value) }
+            elementResult.resultOrPartial().ifPresent { pair -> elements.add(pair.getFirst()) }
+            result = result.apply2stable({ result, element -> result }, elementResult)
+        }
+
+        fun build(): DataResult<Pair<MutableList<E>, T>> {
+            if (elements.size() < minSize) {
+                return createTooShortError(elements.size())
+            }
+            val errors = ops.createList(failed.build())
+            val pair: Pair<MutableList<E>, T> = Pair.of(elements.toMutableList(), errors)
+            if (totalCount > maxSize) {
+                result = createTooLongError(totalCount)
+            }
+            return result.map { ignored -> pair }.setPartial(pair)
+        }
+    }
+}

--- a/src/main/java/net/frozenblock/configurableeverything/util/MutableListCodec.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/util/MutableListCodec.kt
@@ -10,7 +10,7 @@ import com.mojang.serialization.DynamicOps
 import com.mojang.serialization.Lifecycle
 import com.mojang.serialization.ListBuilder
 import com.mojang.serialization.codecs.ListCodec
-import java.util.Stream
+import java.util.stream.Stream
 
 inline fun <T> Codec<T>.mutListOf(minSize: Int = 0, maxSize: Int = Int.MAX_VALUE): Codec<MutableList<T>>
     = mutList(this, minSize, maxSize)
@@ -52,13 +52,13 @@ data class MutableListCodec<E>(private val elementCodec: Codec<E>, private val m
     private inner class DecoderState<T>(private val ops: DynamicOps<T>) {
 
         private val elements: MutableList<E> = mutableListOf()
-        private val failed: Steam.Builder<T> = Stream.builder();
+        private val failed: Stream.Builder<T> = Stream.builder();
         private var result: DataResult<DFUUnit> = INITIAL_RESULT
-        private var totalCount: Int
+        private var totalCount: Int = 0
 
         fun accept(value: T) {
             totalCount++
-            if (elements.size() >= maxSize) {
+            if (elements.size >= maxSize) {
                 failed.add(value)
                 return
             }
@@ -69,15 +69,15 @@ data class MutableListCodec<E>(private val elementCodec: Codec<E>, private val m
         }
 
         fun build(): DataResult<Pair<MutableList<E>, T>> {
-            if (elements.size() < minSize) {
-                return createTooShortError(elements.size())
+            if (elements.size < minSize) {
+                return createTooShortError(elements.size)
             }
             val errors = ops.createList(failed.build())
             val pair: Pair<MutableList<E>, T> = Pair.of(elements.toMutableList(), errors)
             if (totalCount > maxSize) {
                 result = createTooLongError(totalCount)
             }
-            return result.map { ignored -> pair }.setPartial(pair)
+            return result.map { pair }.setPartial(pair)
         }
     }
 }

--- a/src/main/java/net/frozenblock/configurableeverything/util/MutableListCodec.kt
+++ b/src/main/java/net/frozenblock/configurableeverything/util/MutableListCodec.kt
@@ -9,7 +9,8 @@ import com.mojang.serialization.DataResult
 import com.mojang.serialization.DynamicOps
 import com.mojang.serialization.Lifecycle
 import com.mojang.serialization.ListBuilder
-import com.mojang.serialization.codecs.ListCodec;
+import com.mojang.serialization.codecs.ListCodec
+import java.util.Stream
 
 inline fun <T> Codec<T>.mutListOf(minSize: Int = 0, maxSize: Int = Int.MAX_VALUE): Codec<MutableList<T>>
     = mutList(this, minSize, maxSize)
@@ -20,7 +21,7 @@ inline fun <T> mutList(elementCodec: Codec<T>, minSize: Int = 0, maxSize: Int = 
 /**
  * Based on Mojang's ListCodec
  */
-data class MutableListCodec<E>(elementCodec: Codec<E>, minSize: Int = 0, maxSize: Int = Int.MAX_VALUE) : Codec<MutableList<E>> {
+data class MutableListCodec<E>(private val elementCodec: Codec<E>, private val minSize: Int = 0, private val maxSize: Int = Int.MAX_VALUE) : Codec<MutableList<E>> {
     private val delegate = ListCodec(elementCodec, minSize, maxSize)
 
     private fun <R> createTooShortError(size: Int): DataResult<R>
@@ -44,10 +45,11 @@ data class MutableListCodec<E>(elementCodec: Codec<E>, minSize: Int = 0, maxSize
     override fun toString(): String
         = "MutableListCodec[${elementCodec}]"
 
+    companion object {
+        private val INITIAL_RESULT: DataResult<DFUUnit> = DataResult.success(DFUUnit.INSTANCE, Lifecycle.stable())
+    }
+
     private inner class DecoderState<T>(private val ops: DynamicOps<T>) {
-        companion object {
-            private val INITIAL_RESULT: DataResult<DFUUnit> = DataResult.success(DFUUnit.INSTANCE, Lifecycle.stable())
-        }
 
         private val elements: MutableList<E> = mutableListOf()
         private val failed: Steam.Builder<T> = Stream.builder();


### PR DESCRIPTION
Simplifies the process of modifying typed entries via scripts

Before, a copy of the typed entry would have to be created

This is the new format:
```kotlin
ConfigData.STRUCTURE.modify { config ->
   config.removedStructures.add(ResourceLocation("minecraft:ancient_city"))
}
```
Much simpler